### PR TITLE
Added GBIF-backbone support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,7 @@ Building the docker image
 `
 docker build -f docker/Dockerfile . -t ala-namematching-service:v20200214-2
 `
-
+for use ALA namematching and for use the GBIF backbone:
+`
+docker build -f docker/Dockerfile . -t  ala-namematching-service:v2020061714-2 --build-arg ENV=gbif-backbone
+`

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM java:openjdk-8-jre-alpine
 
+ARG ENV
+
 RUN apk --no-cache add curl
 
 RUN mkdir -p /data/lucene
@@ -10,11 +12,14 @@ COPY ./src/main/resources/groups.json /data/ala-namematching-service/config/grou
 COPY ./target/ala-namematching-service-1.0-SNAPSHOT.jar /data/ala-namematching-service.jar
 COPY ./config.yml /data/config.yml
 
-RUN curl -sf  -o /data/lucene/namematching.tgz -L https://archives.ala.org.au/archives/nameindexes/latest/namematching-20200214.tgz
+RUN if [ "$ENV" = "gbif-backbone" ]; then \
+    curl -sf  -o /data/lucene/namematching.tgz -L https://demo.gbif.es/local-files/nameindex-gbif-backbone-nov-2019-11-08.tgz; else \
+    curl -sf  -o /data/lucene/namematching.tgz -L https://archives.ala.org.au/archives/nameindexes/latest/namematching-20200214.tgz; fi
 #COPY namematching.tgz /data/lucene/namematching.tgz
 
 RUN tar zxf /data/lucene/namematching.tgz -C /data/lucene
-RUN mv /data/lucene/namematching-20200214 /data/lucene/namematching
+RUN if [ "$ENV" != "gbif-backbone" ]; then \
+    mv /data/lucene/namematching-20200214 /data/lucene/namematching; fi
 
 EXPOSE 9179
 EXPOSE 9180

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ COPY ./target/ala-namematching-service-1.0-SNAPSHOT.jar /data/ala-namematching-s
 COPY ./config.yml /data/config.yml
 
 RUN if [ "$ENV" = "gbif-backbone" ]; then \
-    curl -sf  -o /data/lucene/namematching.tgz -L https://demo.gbif.es/local-files/nameindex-gbif-backbone-nov-2019-11-08.tgz; else \
+    curl -sf  -o /data/lucene/namematching.tgz -L https://datos.gbif.es/others/namematching-gbif-backbone-2020-06-18.tgz; else \
     curl -sf  -o /data/lucene/namematching.tgz -L https://archives.ala.org.au/archives/nameindexes/latest/namematching-20200214.tgz; fi
 #COPY namematching.tgz /data/lucene/namematching.tgz
 


### PR DESCRIPTION
I just added a build variable to use the Gbif Taxonomy Backbone.

Some screenshots of the query:

![ala-name-docker-gbif-backbone](https://user-images.githubusercontent.com/180085/84934522-b9ce8c80-b0d7-11ea-8f11-6dba250fb863.png)

![ala-name-docker-ala](https://user-images.githubusercontent.com/180085/84934525-ba672300-b0d7-11ea-9005-970c6f08e64e.png)

I'll update the demo.gbif.es link with a improved version of this gist I'm testing right now:
https://gist.github.com/vjrj/60b68a68af76bfaa6cd54c1a787d88b7