### PR TITLE
Added mvn build to debian/rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dependency-reduced-pom.xml
 *.substvars
 debian/files
 debian/ala-namematching-service
+debian/debhelper-build-stamp

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,16 +1,16 @@
-ala-namematching-service (1.0-SNAPSHOT-3) unstable; urgency=medium
+ala-namematching-service (1.0-SNAPSHOT+0~20200914091638.1) unstable; urgency=medium
 
   * Added SHA1 checksum
 
  -- ALA Development Team <support@ala.org.au>  Mon, 14 Sep 2020 09:16:38 +0200
 
-ala-namematching-service (1.0-SNAPSHOT-2) unstable; urgency=medium
+ala-namematching-service (1.0-SNAPSHOT+0~20200911170711.1) unstable; urgency=medium
 
   * Dependencies improved
 
  -- ALA Development Team <support@ala.org.au>  Fri, 11 Sep 2020 17:07:11 +0200
 
-ala-namematching-service (1.0-SNAPSHOT-1) unstable; urgency=low
+ala-namematching-service (1.0-SNAPSHOT+0~20200911111645.1) unstable; urgency=low
 
   * Initial release
 

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,6 @@ Priority: optional
 Maintainer: ALA Development Team <support@ala.org.au>
 Uploaders: ALA Development Team <support@ala.org.au>
 Build-Depends:
-Build-Depends:
  debhelper (>= 11),
  openjdk-8-jdk,
  maven

--- a/debian/control
+++ b/debian/control
@@ -4,8 +4,10 @@ Priority: optional
 Maintainer: ALA Development Team <support@ala.org.au>
 Uploaders: ALA Development Team <support@ala.org.au>
 Build-Depends:
+Build-Depends:
  debhelper (>= 11),
- default-jdk
+ openjdk-8-jdk,
+ maven
 Standards-Version: 4.2.1
 Homepage: https://github.com/AtlasOfLivingAustralia/ala-namematching-service
 Vcs-Browser: https://github.com/AtlasOfLivingAustralia/ala-namematching-service

--- a/debian/rules
+++ b/debian/rules
@@ -21,7 +21,7 @@ ifeq ($(filter nobuildjar,$(DEB_BUILD_PROFILES)),)
 # This allows to skip the maven jar build (for instance, if its builded by another jenkins job)
 # for instance with debuild -us -uc -b --build-profiles=nobuildjar
 # Also we can -DskipITs tests
-	mvn -Dmaven.repo.local=$(M2_REPO) clean install
+	mvn -Dmaven.repo.local=$(M2_REPO) clean install -DskipTests
 endif
 
 override_dh_auto_install:

--- a/debian/rules
+++ b/debian/rules
@@ -20,8 +20,7 @@ override_dh_auto_build:
 ifeq ($(filter nobuildjar,$(DEB_BUILD_PROFILES)),)
 # This allows to skip the maven jar build (for instance, if its builded by another jenkins job)
 # for instance with debuild -us -uc -b --build-profiles=nobuildjar
-# Also we can -DskipITs tests
-	mvn -Dmaven.repo.local=$(M2_REPO) clean install -DskipTests
+	mvn -Dmaven.repo.local=$(M2_REPO) clean install -DskipTests=true
 endif
 
 override_dh_auto_install:

--- a/debian/rules
+++ b/debian/rules
@@ -12,10 +12,21 @@
 %:
 	dh $@ --with-systemd
 
-build:
-#	install don't allow to rename files (like wars), so we copy here the file we want to install with the package
+CURVERSION=$(shell grep -oPm2 "(?<=<version>)[^<]+" "pom.xml" | tail -1)
+# Set the m2 repo local for fakeroot
+M2_REPO=/var/tmp/m2
+
+override_dh_auto_build:
+ifeq ($(filter nobuildjar,$(DEB_BUILD_PROFILES)),)
+# This allows to skip the maven jar build (for instance, if its builded by another jenkins job)
+# for instance with debuild -us -uc -b --build-profiles=nobuildjar
+# Also we can -DskipITs tests
+	mvn -Dmaven.repo.local=$(M2_REPO) clean install
+endif
+
+override_dh_auto_install:
 # $(CURDIR) is the repo directory
-	cp $(CURDIR)/server/target/ala-namematching-server-1.0-SNAPSHOT.jar $(CURDIR)/server/target/ala-namematching-server.jar
+	cp $(CURDIR)/server/target/ala-namematching-server-$(CURVERSION).jar $(CURDIR)/server/target/ala-namematching-server.jar
 
 override_dh_fixperms:
 	dh_fixperms


### PR DESCRIPTION
In order to create some jenkins jobs to auto build the package, I added an optional `mvn clean install` to the build rules and I removed the hard coded version.