### PR TITLE
Allow bulk lookup and synonym following

### DIFF
--- a/client/src/main/java/au/org/ala/names/ws/client/ALANameUsageMatchRetrofitService.java
+++ b/client/src/main/java/au/org/ala/names/ws/client/ALANameUsageMatchRetrofitService.java
@@ -46,7 +46,19 @@ interface ALANameUsageMatchRetrofitService {
 
     @GET("/api/getByTaxonID")
     @Headers({"Content-Type: application/json"})
-    Call<NameUsageMatch> get(@Query("taxonID") String taxonID);
+    Call<NameUsageMatch> get(@Query("taxonID") String taxonID, @Query("follow") boolean follow);
+
+    @POST("/api/getAllByTaxonID")
+    @Headers({"Content-Type: application/json"})
+    Call<List<NameUsageMatch>> getAll(@Query("taxonIDs") List<String> taxonIDs, @Query("follow") boolean follow);
+
+    @GET("/api/getNameByTaxonID")
+    @Headers({"Content-Type: application/json"})
+    Call<String> getName(@Query("taxonID") String taxonID, @Query("follow") boolean follow);
+
+    @POST("/api/getAllNamesByTaxonID")
+    @Headers({"Content-Type: application/json"})
+    Call<List<String>> getAllNames(@Query("taxonIDs") List<String> taxonIDs, @Query("follow") boolean follow);
 
     @GET("/api/check")
     @Headers({"Content-Type: application/json"})

--- a/client/src/main/java/au/org/ala/names/ws/client/ALANameUsageMatchServiceClient.java
+++ b/client/src/main/java/au/org/ala/names/ws/client/ALANameUsageMatchServiceClient.java
@@ -183,8 +183,45 @@ public class ALANameUsageMatchServiceClient implements NameMatchService {
      * @return A matching taxon, with success=false if not found
      */
     @Override
-    public NameUsageMatch get(String taxonID) {
-        return this.call(this.alaNameUsageMatchService.get(taxonID));
+    public NameUsageMatch get(String taxonID, boolean follow) {
+        return this.call(this.alaNameUsageMatchService.get(taxonID, follow));
+    }
+
+    /**
+     * Bulk lookup of taxon information for a list of taxon identifiers.
+     *
+     * @param taxonIDs The list of taxon identifiers
+     * @param follow Follow synonyms to the accepted taxon
+     *
+     * @return The list of matches, will fail results for no match.
+     */
+    @Override
+    public List<NameUsageMatch> getAll(List<String> taxonIDs, boolean follow) {
+        return this.call(this.alaNameUsageMatchService.getAll(taxonIDs, follow));
+    }
+
+    /**
+     * Get the scientific name for a specific taxon identifier.
+     *
+     * @param taxonID The taxon identifier
+     * @param follow  Follow syonynms to return the accepted taxon
+     * @return The matching name, or null for not found
+     */
+    @Override
+    public String getName(String taxonID, boolean follow) {
+        return this.call(this.alaNameUsageMatchService.getName(taxonID, follow));
+    }
+
+    /**
+     * Bulk lookup of scientific names for taxon identifiers.
+     *
+     * @param taxonIDs The taxon identifiers
+     * @param follow   Follow syonynms to return the accepted taxon
+     * @return A list containing the matching name The matching taxon, or null for not found
+     */
+    @Override
+    public List<String> getAllNames(List<String> taxonIDs, boolean follow) {
+        return this.call(this.alaNameUsageMatchService.getAllNames(taxonIDs, follow));
     }
 
     @Override

--- a/client/src/test/java/au/org/ala/names/ws/client/ALANameUsageMatchServiceClientIT.java
+++ b/client/src/test/java/au/org/ala/names/ws/client/ALANameUsageMatchServiceClientIT.java
@@ -117,6 +117,131 @@ public class ALANameUsageMatchServiceClientIT extends TestUtils {
     }
 
     @Test
+    public void testGet1() throws Exception {
+        NameUsageMatch match = client.get("urn:lsid:biodiversity.org.au:afd.taxon:2d605472-979b-49b4-aed3-03a384e9f706");
+        assertNotNull(match);
+        assertTrue(match.isSuccess());
+        assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:2d605472-979b-49b4-aed3-03a384e9f706", match.getTaxonConceptID());
+        assertEquals("Chelonia mydas", match.getScientificName());
+    }
+
+    @Test
+    public void testGet2() throws Exception {
+        NameUsageMatch match = client.get("urn:lsid:biodiversity.org.au:afd.name:a838ad85-6ead-4bd2-8741-75f571d7062f");
+        assertNotNull(match);
+        assertTrue(match.isSuccess());
+        assertEquals("urn:lsid:biodiversity.org.au:afd.name:a838ad85-6ead-4bd2-8741-75f571d7062f", match.getTaxonConceptID());
+        assertEquals("Caretta esculenta", match.getScientificName());
+    }
+
+    @Test
+    public void testGet3() throws Exception {
+        NameUsageMatch match = client.get("urn:lsid:biodiversity.org.au:afd.name:a838ad85-6ead-4bd2-8741-75f571d7062f", false);
+        assertNotNull(match);
+        assertTrue(match.isSuccess());
+        assertEquals("urn:lsid:biodiversity.org.au:afd.name:a838ad85-6ead-4bd2-8741-75f571d7062f", match.getTaxonConceptID());
+        assertEquals("Caretta esculenta", match.getScientificName());
+    }
+
+    @Test
+    public void testGet4() throws Exception {
+        NameUsageMatch match = client.get("urn:lsid:biodiversity.org.au:afd.name:a838ad85-6ead-4bd2-8741-75f571d7062f", true);
+        assertNotNull(match);
+        assertTrue(match.isSuccess());
+        assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:2d605472-979b-49b4-aed3-03a384e9f706", match.getTaxonConceptID());
+        assertEquals("Chelonia mydas", match.getScientificName());
+    }
+
+    @Test
+    public void testGet5() throws Exception {
+        NameUsageMatch match = client.get("Well, this is silly", true);
+        assertNotNull(match);
+        assertFalse(match.isSuccess());
+    }
+
+    @Test
+    public void testGetAll1() throws Exception {
+        List<String> ids = Arrays.asList(
+                "https://id.biodiversity.org.au/taxon/apni/51286863",
+                "urn:lsid:biodiversity.org.au:afd.taxon:2d605472-979b-49b4-aed3-03a384e9f706",
+                "urn:lsid:biodiversity.org.au:afd.name:a838ad85-6ead-4bd2-8741-75f571d7062f",
+                "A random unknown id"
+        );
+        List<NameUsageMatch> matches = client.getAll(ids, false);
+        assertNotNull(matches);
+        assertEquals(ids.size(), matches.size());
+        NameUsageMatch match = matches.get(0);
+        assertTrue(match.isSuccess());
+        assertEquals("https://id.biodiversity.org.au/taxon/apni/51286863", match.getTaxonConceptID());
+        assertEquals("Acacia dealbata", match.getScientificName());
+        match = matches.get(1);
+        assertTrue(match.isSuccess());
+        assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:2d605472-979b-49b4-aed3-03a384e9f706", match.getTaxonConceptID());
+        assertEquals("Chelonia mydas", match.getScientificName());
+        match = matches.get(2);
+        assertTrue(match.isSuccess());
+        assertEquals("urn:lsid:biodiversity.org.au:afd.name:a838ad85-6ead-4bd2-8741-75f571d7062f", match.getTaxonConceptID());
+        assertEquals("Caretta esculenta", match.getScientificName());
+        match = matches.get(3);
+        assertFalse(match.isSuccess());
+    }
+
+    @Test
+    public void testGetAll2() throws Exception {
+        List<String> ids = Arrays.asList(
+                "https://id.biodiversity.org.au/taxon/apni/51286863",
+                "urn:lsid:biodiversity.org.au:afd.taxon:2d605472-979b-49b4-aed3-03a384e9f706",
+                "urn:lsid:biodiversity.org.au:afd.name:a838ad85-6ead-4bd2-8741-75f571d7062f"
+        );
+        List<NameUsageMatch> matches = client.getAll(ids, true);
+        assertNotNull(matches);
+        assertEquals(ids.size(), matches.size());
+        NameUsageMatch match = matches.get(0);
+        assertTrue(match.isSuccess());
+        assertEquals("https://id.biodiversity.org.au/taxon/apni/51286863", match.getTaxonConceptID());
+        assertEquals("Acacia dealbata", match.getScientificName());
+        match = matches.get(1);
+        assertTrue(match.isSuccess());
+        assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:2d605472-979b-49b4-aed3-03a384e9f706", match.getTaxonConceptID());
+        assertEquals("Chelonia mydas", match.getScientificName());
+        match = matches.get(2);
+        assertTrue(match.isSuccess());
+        assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:2d605472-979b-49b4-aed3-03a384e9f706", match.getTaxonConceptID());
+        assertEquals("Chelonia mydas", match.getScientificName());
+        assertEquals("SYNONYM", match.getSynonymType());
+    }
+
+
+    @Test
+    public void testGetName1() throws Exception {
+        String name = client.getName("urn:lsid:biodiversity.org.au:afd.name:a838ad85-6ead-4bd2-8741-75f571d7062f", false);
+        assertNotNull(name);
+        assertEquals("Caretta esculenta", name);
+    }
+
+    @Test
+    public void testGetName2() throws Exception {
+        String name = client.getName("urn:lsid:biodiversity.org.au:afd.name:a838ad85-6ead-4bd2-8741-75f571d7062f", true);
+        assertNotNull(name);
+         assertEquals("Chelonia mydas", name);
+    }
+
+    @Test
+    public void testGetAllNames1() throws Exception {
+        List<String> ids = Arrays.asList(
+                "https://id.biodiversity.org.au/taxon/apni/51286863",
+                "urn:lsid:biodiversity.org.au:afd.taxon:2d605472-979b-49b4-aed3-03a384e9f706",
+                "urn:lsid:biodiversity.org.au:afd.name:a838ad85-6ead-4bd2-8741-75f571d7062f"
+        );
+        List<String> names = client.getAllNames(ids, true);
+        assertNotNull(names);
+        assertEquals(ids.size(), names.size());
+        assertEquals("Acacia dealbata", names.get(0));
+        assertEquals("Chelonia mydas", names.get(1));
+        assertEquals("Chelonia mydas", names.get(2));
+    }
+
+    @Test
     public void testCheck1() throws Exception {
         Boolean valid = client.check("Animalia", "kingdom");
         assertNotNull(valid);

--- a/core/src/main/java/au/org/ala/names/ws/api/NameMatchService.java
+++ b/core/src/main/java/au/org/ala/names/ws/api/NameMatchService.java
@@ -83,12 +83,59 @@ public interface NameMatchService extends Closeable {
 
     /**
      * Get taxon information via a specific taxon identifier.
+     * <p>
+     * See {@link #get(String, boolean)}. By default, synonyms are not followed.
+     * </p>
      *
      * @param taxonID The taxon identifier
+      *
+     * @return A matching taxon, with success=false if not found
+     */
+    default NameUsageMatch get(String taxonID) {
+        return this.get(taxonID, false);
+    }
+
+    /**
+     * Get taxon information via a specific taxon identifier.
+     *
+     * @param taxonID The taxon identifier
+     * @param follow Follow syonynms to return the accepted taxon
      *
      * @return A matching taxon, with success=false if not found
      */
-    NameUsageMatch get(String taxonID);
+    NameUsageMatch get(String taxonID, boolean follow);
+
+    /**
+     * Get the scientific name for a specific taxon identifier.
+     *
+     * @param taxonID The taxon identifier
+     * @param follow Follow syonynms to return the accepted taxon
+     *
+     * @return The matching name, or null for not found
+     */
+    String getName(String taxonID, boolean follow);
+
+    /**
+     * Bulk lookup for taxon identifiers
+     *
+     * @param taxonIDs The list of taxon identifiers
+     *
+     * @return A corresponding list of name match results
+     * @param follow Follow synonyms to the accepted taxon
+     *
+     * @see #get(String, boolean)
+     */
+    List<NameUsageMatch> getAll(List<String> taxonIDs, boolean follow);
+
+    /**
+     * Bulk lookup for scientific names for taxon identifiers.
+     *
+     * @param taxonIDs The taxon identifiers
+     * @param follow Follow syonynms to return the accepted taxon
+     *
+     * @return A list containing the matching name The matching taxon, or null for not found
+     */
+    List<String> getAllNames(List<String> taxonIDs, boolean follow);
 
     /**
      * Check to see if a given name is in the index for this rank.
@@ -100,13 +147,55 @@ public interface NameMatchService extends Closeable {
      */
     Boolean check(String name, String rank);
 
+    /**
+     * Lookup a partial name for autocomplete
+     *
+     * @param query The partial name
+     * @param max The maximum number of results
+     * @param includeSynonyms Include synonyms, as well as accepted names, in the results
+     *
+     * @return A map of partial matches
+     */
     List<Map> autocomplete(String query, Integer max, Boolean includeSynonyms);
 
+
+    /**
+     * Search for the correct taxon identifier for a supplied identifier.
+     * <p>
+     * If a taxon has an 'alias' identifer, then this method can be used to find the used identifier
+     * </p>
+     *
+     * @param id The identifier
+     *
+     * @return The correct LSID, null or empty for a missing id
+     */
     String searchForLsidById(String id);
 
+    /**
+     * Get the taxon identifier corresponding to a sciencitfic name
+     *
+     * @param name The scientific name
+     *
+     * @return The corresponding taxon identifier
+     */
     String searchForLSID(String name);
 
+    /**
+     * Get a list of taxon identifiers corresponding to a list of names
+     *
+     * @param taxaQueries The queries
+     *
+     * @return A list of matching identifiers
+     */
     List<String> getGuidsForTaxa(List<String> taxaQueries);
 
+    /**
+     * Get the full list of common names associated with a taxon.
+     *
+     * @param lsid The taxon identifier
+     * @param max The maximum number of results
+     *
+     * @return A set of common names
+     */
     Set<String> getCommonNamesForLSID(String lsid, Integer max);
 }

--- a/server/src/main/java/au/org/ala/names/ws/core/SpeciesGroupsUtil.java
+++ b/server/src/main/java/au/org/ala/names/ws/core/SpeciesGroupsUtil.java
@@ -193,9 +193,11 @@ public class SpeciesGroupsUtil {
 
     private List<String> getGenericGroups(Integer lft, List<SpeciesGroup> groupingList) {
         List<String> matchedGroups = new ArrayList<String>();
-        for(SpeciesGroup sg : groupingList) {
-            if (sg.isPartOfGroup(lft)) {
-                matchedGroups.add(sg.name);
+        if (lft != null) {
+            for (SpeciesGroup sg : groupingList) {
+                if (sg.isPartOfGroup(lft)) {
+                    matchedGroups.add(sg.name);
+                }
             }
         }
         return matchedGroups;

--- a/server/src/test/java/au/org/ala/names/ws/resources/NameSearchResourceTest.java
+++ b/server/src/test/java/au/org/ala/names/ws/resources/NameSearchResourceTest.java
@@ -221,7 +221,6 @@ public class NameSearchResourceTest {
         assertEquals(Collections.singletonList("noIssue"), match.getIssues());
     }
 
-
     @Test
     public void testGetByTaxonID1() throws Exception {
         NameUsageMatch match = this.resource.get("https://id.biodiversity.org.au/taxon/apni/51286863");
@@ -233,6 +232,115 @@ public class NameSearchResourceTest {
         assertEquals(Collections.singletonList("noIssue"), match.getIssues());
     }
 
+    @Test
+    public void testGetByTaxonID2() throws Exception {
+        // Search by synonym ID
+        NameUsageMatch match = this.resource.get("NZOR-6-99065", false);
+        assertTrue(match.isSuccess());
+        assertEquals("NZOR-6-99065", match.getTaxonConceptID());
+        assertEquals("Lens esculenta", match.getScientificName());
+        assertNull(match.getNameType());
+        assertEquals("taxonIdMatch", match.getMatchType());
+        assertEquals(Collections.singletonList("noIssue"), match.getIssues());
+    }
+
+    @Test
+    public void testGetByTaxonID3() throws Exception {
+        NameUsageMatch match = this.resource.get("NZOR-6-99065", true);
+        assertTrue(match.isSuccess());
+        assertEquals("NZOR-6-131797", match.getTaxonConceptID());
+        assertEquals("Lens culinaris", match.getScientificName());
+        assertNull(match.getNameType());
+        assertEquals("taxonIdMatch", match.getMatchType());
+        assertEquals(Collections.singletonList("noIssue"), match.getIssues());
+    }
+
+
+    @Test
+    public void testGetNameTaxonID1() throws Exception {
+        String name = this.resource.getName("https://id.biodiversity.org.au/taxon/apni/51286863", false);
+        assertEquals("Acacia dealbata", name);
+    }
+
+    @Test
+    public void testGetNameByTaxonID2() throws Exception {
+        String name = this.resource.getName("NZOR-6-99065", false);
+        assertEquals("Lens esculenta", name);
+    }
+
+    @Test
+    public void testGetNameByTaxonID3() throws Exception {
+        String name = this.resource.getName("NZOR-6-99065", true);
+        assertEquals("Lens culinaris", name);
+    }
+
+
+    @Test
+    public void testGetAllByTaxonID1() throws Exception {
+        List<String> ids = Arrays.asList(
+                "https://id.biodiversity.org.au/taxon/apni/51286863",
+                "urn:lsid:biodiversity.org.au:afd.taxon:2d605472-979b-49b4-aed3-03a384e9f706"
+        );
+        List<NameUsageMatch> matches = this.resource.getAll(ids, false);
+        assertEquals(ids.size(), matches.size());
+        NameUsageMatch match = matches.get(0);
+        assertTrue(match.isSuccess());
+        assertEquals("https://id.biodiversity.org.au/taxon/apni/51286863", match.getTaxonConceptID());
+        assertEquals("Acacia dealbata", match.getScientificName());
+        match = matches.get(1);
+        assertTrue(match.isSuccess());
+        assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:2d605472-979b-49b4-aed3-03a384e9f706", match.getTaxonConceptID());
+        assertEquals("Chelonia mydas", match.getScientificName());
+    }
+
+    @Test
+    public void testGetAllByTaxonID2() throws Exception {
+        List<String> ids = Arrays.asList(
+                "https://id.biodiversity.org.au/taxon/apni/51286863",
+                "NothingToSeeHere"
+        );
+        List<NameUsageMatch> matches = this.resource.getAll(ids, false);
+        assertEquals(ids.size(), matches.size());
+        NameUsageMatch match = matches.get(0);
+        assertTrue(match.isSuccess());
+        assertEquals("https://id.biodiversity.org.au/taxon/apni/51286863", match.getTaxonConceptID());
+        assertEquals("Acacia dealbata", match.getScientificName());
+        match = matches.get(1);
+        assertFalse(match.isSuccess());
+    }
+
+    @Test
+    public void testGetAllByTaxonID3() throws Exception {
+        List<String> ids = Arrays.asList(
+                "https://id.biodiversity.org.au/taxon/apni/51286863",
+                "NZOR-6-99065"
+        );
+        List<NameUsageMatch> matches = this.resource.getAll(ids, true);
+        assertEquals(ids.size(), matches.size());
+        NameUsageMatch match = matches.get(0);
+        assertTrue(match.isSuccess());
+        assertEquals("https://id.biodiversity.org.au/taxon/apni/51286863", match.getTaxonConceptID());
+        assertEquals("Acacia dealbata", match.getScientificName());
+        match = matches.get(1);
+        assertTrue(match.isSuccess());
+        assertEquals("NZOR-6-131797", match.getTaxonConceptID());
+        assertEquals("Lens culinaris", match.getScientificName());
+    }
+
+
+    @Test
+    public void testGetAllNamesByTaxonID1() throws Exception {
+        List<String> ids = Arrays.asList(
+                "https://id.biodiversity.org.au/taxon/apni/51286863",
+                "NZOR-6-99065",
+                "Nothing to be ashamed of"
+        );
+        List<String> matches = this.resource.getAllNames(ids, true);
+        assertEquals(ids.size(), matches.size());
+        assertEquals("Acacia dealbata", matches.get(0));
+        assertEquals("Lens culinaris", matches.get(1));
+        assertNull(matches.get(2));
+    }
 
     @Test
     public void testSearchByVerncaularName1() throws Exception {


### PR DESCRIPTION
Fixes for https://github.com/AtlasOfLivingAustralia/la-pipelines/issues/370

Provide get(), getAll(), getName(), getAllNames() methods to the client.
Allow get operations to follow or not follow synonym dereferencing.
Fix number format exception/NPE with gets on synonyms.