### PR TITLE
Namematching debian package update

### DIFF
--- a/debian/ala-namematching-service.postinst
+++ b/debian/ala-namematching-service.postinst
@@ -67,6 +67,13 @@ case "$1" in
             fi
         fi
         chown -R namematching:namematching /data/lucene/namematching/
+
+        # Restart the service with the downloaded namematching
+
+        if [ -d /run/systemd/system ]; then
+            deb-systemd-invoke restart ala-namematching-service.service || true
+        fi
+
     ;;
 esac
 

--- a/debian/ala-namematching-service.postinst
+++ b/debian/ala-namematching-service.postinst
@@ -35,14 +35,16 @@ case "$1" in
 
         echo "Downloading nameindex $URL ..."
 
-        # Try to resume previous download
-        curl -sLC - -o "$DEST" "$URL"
+        # Try to resume previous download (continue if fails)
+        set +e
+        curl -sLC - -o "$DEST" -f "$URL"
+        set -e
 
         SHA1_DOWNLOADED=$(sha1sum $DEST | awk '{ print $1 }')
 
         # Downloaded file sha1 does not match provided sha1, so retry full download
         if [[ "$SHA1" != "$SHA1_DOWNLOADED" ]]; then
-            echo "SHA1 does not match, trying to download again $URL ..."
+            echo "SHA1 does not match ($SHA1 vs $SHA1_DOWNLOADED), trying to download again $URL ..."
             curl -sL -o "$DEST" "$URL"
         fi
 
@@ -51,7 +53,7 @@ case "$1" in
         ROOTDIR2=$(tar tf $DEST | head -1 | cut -d "/" -f 2)
 
         echo "Untar nameindex source ..."
-        tar zxf $DEST -C /tmp/
+        tar zxf $DEST -C /tmp/ --no-same-owner
 
         if [[ -n "$ROOTDIR1" && ${#ROOTDIR1} -gt 1 ]]; then
             echo "Provided nameindex tar uses $ROOTDIR1 as root directory"

--- a/debian/ala-namematching-service.templates
+++ b/debian/ala-namematching-service.templates
@@ -1,9 +1,9 @@
 Template: ala-namematching-service/source
 Type: string
-Default: https://archives.ala.org.au/archives/nameindexes/latest/namematching-20210811.tgz
+Default: https://archives.ala.org.au/archives/nameindexes/20210811/namematching-20210811.tgz
 Description: Pre-built name matching index tar
 
 Template: ala-namematching-service/sha1
 Type: string
-Default: f9e42325db8d41ca0c8afeb6aeadf670978a13ac
+Default: 563814a7b5d886b746e10eb40c44f0d9bda62371
 Description: SHA1 of the previous tar

--- a/server/docker/Dockerfile
+++ b/server/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get install -y -q openjdk-8-jdk rsync tar curl
 # If we want to change the default URL over time
 RUN echo "ala-namematching-service ala-namematching-service/source string https://archives.ala.org.au/archives/nameindexes/20210811/namematching-20210811.tgz" | debconf-set-selections
 # SHA1 of the previous file
-RUN echo "ala-namematching-service ala-namematching-service/sha1 string f9e42325db8d41ca0c8afeb6aeadf670978a13ac" | debconf-set-selections
+RUN echo "ala-namematching-service ala-namematching-service/sha1 string 563814a7b5d886b746e10eb40c44f0d9bda62371" | debconf-set-selections
 
 # Update the next commented date to force a new docker hub build with an updated la-pipelines version
 RUN apt-get -y update && \


### PR DESCRIPTION
This PR:
- Fix some tar error installing the debian package:
``` 
Untar nameindex source ...
tar: namematching-20210811/vernacular: Cannot change ownership to uid 113379, gid 113379: Invalid argument
tar: namematching-20210811/irmng: Cannot change ownership to uid 113379, gid 113379: Invalid argument
(...)
```
- Update the default url same as Dockerfile to prevent 404 when installing the debian package directly
- Update sha1 values to the name name index
- Improve the postinstall curl resume and messages
