### PR TITLE
Debian dest reconfigured

### DIFF
--- a/debian/ala-namematching-service.install
+++ b/debian/ala-namematching-service.install
@@ -1,6 +1,6 @@
 # https://www.debian.org/doc/manuals/maint-guide/dother.en.html#install
 server/src/main/resources/subgroups.json data/ala-namematching-service/config/
 server/src/main/resources/groups.json data/ala-namematching-service/config/
-server/target/ala-namematching-server.jar data/
+server/target/ala-namematching-server.jar opt/atlas/ala-namematching-service/
 # TODO: we should move this to other location and with other name referencing to this service
-server/config.yml data/
+server/config.yml data/ala-namematching-service/config/

--- a/debian/ala-namematching-service.postinst
+++ b/debian/ala-namematching-service.postinst
@@ -25,12 +25,13 @@ case "$1" in
         db_get ala-namematching-service/sha1
         SHA1=$RET
 
-        DEST=/data/lucene/namematching.tgz
+        DEST=/data/lucene/namematching-nm.tgz
+        FINAL_DEST=/data/lucene/namematching-nm/
 
         # To prevent /data/lucene installed nameindexes to fill our disk:
         #
         # 1) we try to not download the same nameindex again and again (this is why we use curl -C)
-        # 2) we rsync the tar over /data/lucene/namematching overwritting the previous nameindex
+        # 2) we rsync the tar over /data/lucene/namematching-nm overwritting the previous nameindex
         #
 
         echo "Downloading nameindex $URL ..."
@@ -57,16 +58,16 @@ case "$1" in
 
         if [[ -n "$ROOTDIR1" && ${#ROOTDIR1} -gt 1 ]]; then
             echo "Provided nameindex tar uses $ROOTDIR1 as root directory"
-            rsync -a --delete "/tmp/$ROOTDIR1/" /data/lucene/namematching/;
+            rsync -a --delete "/tmp/$ROOTDIR1/" "$FINAL_DEST";
         else
             if [[ -n "$ROOTDIR2" && ${#ROOTDIR2} -gt 1 ]]; then
                 echo "Provided nameindex tar uses $ROOTDIR2 as root directory"
-                rsync -a --delete "/tmp/$ROOTDIR2/" /data/lucene/namematching/;
+                rsync -a --delete "/tmp/$ROOTDIR2/" "$FINAL_DEST";
             else
                 echo "ERROR: Incorrect nameindex tar"
             fi
         fi
-        chown -R namematching:namematching /data/lucene/namematching/
+        chown -R namematching:namematching "$FINAL_DEST"
 
         # Restart the service with the downloaded namematching
 

--- a/debian/ala-namematching-service.postinst
+++ b/debian/ala-namematching-service.postinst
@@ -35,14 +35,16 @@ case "$1" in
 
         echo "Downloading nameindex $URL ..."
 
-        # Try to resume previous download
-        curl -sLC - -o "$DEST" "$URL"
+        # Try to resume previous download (continue if fails)
+        set +e
+        curl -sLC - -o "$DEST" -f "$URL"
+        set -e
 
         SHA1_DOWNLOADED=$(sha1sum $DEST | awk '{ print $1 }')
 
         # Downloaded file sha1 does not match provided sha1, so retry full download
         if [[ "$SHA1" != "$SHA1_DOWNLOADED" ]]; then
-            echo "SHA1 does not match, trying to download again $URL ..."
+            echo "SHA1 does not match ($SHA1 vs $SHA1_DOWNLOADED), trying to download again $URL ..."
             curl -sL -o "$DEST" "$URL"
         fi
 
@@ -51,7 +53,7 @@ case "$1" in
         ROOTDIR2=$(tar tf $DEST | head -1 | cut -d "/" -f 2)
 
         echo "Untar nameindex source ..."
-        tar zxf $DEST -C /tmp/
+        tar zxf $DEST -C /tmp/ --no-same-owner
 
         if [[ -n "$ROOTDIR1" && ${#ROOTDIR1} -gt 1 ]]; then
             echo "Provided nameindex tar uses $ROOTDIR1 as root directory"
@@ -65,6 +67,13 @@ case "$1" in
             fi
         fi
         chown -R namematching:namematching /data/lucene/namematching/
+
+        # Restart the service with the downloaded namematching
+
+        if [ -d /run/systemd/system ]; then
+            deb-systemd-invoke restart ala-namematching-service.service || true
+        fi
+
     ;;
 esac
 

--- a/debian/ala-namematching-service.service
+++ b/debian/ala-namematching-service.service
@@ -1,10 +1,9 @@
 [Unit]
 Description=ala-namematching-service
-After=syslog.target
 
 [Service]
 User=namematching
-ExecStart=/usr/lib/jvm/java-8-openjdk-amd64/bin/java -jar /data/ala-namematching-server.jar server /data/config.yml
+ExecStart=/usr/lib/jvm/java-8-openjdk-amd64/bin/java -jar /opt/atlas/ala-namematching-service/ala-namematching-server.jar server /data/ala-namematching-service/config/config.yml
 SuccessExitStatus=143
 
 [Install]

--- a/debian/ala-namematching-service.templates
+++ b/debian/ala-namematching-service.templates
@@ -1,9 +1,9 @@
 Template: ala-namematching-service/source
 Type: string
-Default: https://archives.ala.org.au/archives/nameindexes/latest/namematching-20210811.tgz
+Default: https://archives.ala.org.au/archives/nameindexes/20210811/namematching-20210811.tgz
 Description: Pre-built name matching index tar
 
 Template: ala-namematching-service/sha1
 Type: string
-Default: f9e42325db8d41ca0c8afeb6aeadf670978a13ac
+Default: 563814a7b5d886b746e10eb40c44f0d9bda62371
 Description: SHA1 of the previous tar

--- a/debian/ala-namematching-service.templates
+++ b/debian/ala-namematching-service.templates
@@ -1,9 +1,9 @@
 Template: ala-namematching-service/source
 Type: string
 Default: https://archives.ala.org.au/archives/nameindexes/20210811/namematching-20210811.tgz
-Description: Pre-built name matching index tar
+Description: Pre-built name matching index tar:
 
 Template: ala-namematching-service/sha1
 Type: string
 Default: 563814a7b5d886b746e10eb40c44f0d9bda62371
-Description: SHA1 of the previous tar
+Description: SHA1 of the previous tar:

--- a/debian/control
+++ b/debian/control
@@ -14,12 +14,12 @@ Vcs-Git: https://github.com/AtlasOfLivingAustralia/ala-namematching-service.git
 
 Package: ala-namematching-service
 Architecture: all
-Depends: ${misc:Depends}, openjdk-8-jdk, ca-certificates, tar (>= 1.0), rsync, curl
+Depends: ${misc:Depends}, openjdk-8-jdk, ca-certificates, tar (>= 1.0), rsync,
+ curl, adduser
 Suggests:
-Description: The ALA Name Matching Service application
+Description: ALA Name Matching Service application
  This package contains the ala-namematching-service package from
  Atlas of Living Australia, Free and open source IT infrastructure
  for the aggregation and delivery of biodiversity data.
  .
- Read: https://github.com/AtlasOfLivingAustralia/documentation/wiki/A-Guide-to-Getting-Names-into-the-ALA
- for a good description
+ Read: https://github.com/AtlasOfLivingAustralia/ala-namematching-service

--- a/server/config.yml
+++ b/server/config.yml
@@ -19,3 +19,5 @@ server:
   adminConnectors:
     - type: http
       port: 9180
+search:
+  index: /data/lucene/namematching-nm

--- a/server/docker/Dockerfile
+++ b/server/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get install -y -q openjdk-8-jdk rsync tar curl
 # If we want to change the default URL over time
 RUN echo "ala-namematching-service ala-namematching-service/source string https://archives.ala.org.au/archives/nameindexes/20210811/namematching-20210811.tgz" | debconf-set-selections
 # SHA1 of the previous file
-RUN echo "ala-namematching-service ala-namematching-service/sha1 string f9e42325db8d41ca0c8afeb6aeadf670978a13ac" | debconf-set-selections
+RUN echo "ala-namematching-service ala-namematching-service/sha1 string 563814a7b5d886b746e10eb40c44f0d9bda62371" | debconf-set-selections
 
 # Update the next commented date to force a new docker hub build with an updated la-pipelines version
 RUN apt-get -y update && \


### PR DESCRIPTION
This PR follows [this thread](https://atlaslivingaustralia.slack.com/archives/CCTFGEU1G/p1643720085551189) and basically:

- untar `namematching` in an alternative `/data/lucene/namematching-nm` directory to prevent collisions with `nameindex` ansible role and `ala-sensitive-data-service` (that uses `lucene` 6 indexes currently) when not using docker
- Fix some lint warnings/errors of the debian package
- Move configurations and jars to directories under `/opt/atlas` and `/data/ala-namematching-service`  instead of `/data`.
- Pulls some debian changes from master

Tested with the dockerfile and ALA def values and also installing the package without docker 