### PR TITLE
Allow loose searches for scientific name

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,12 @@ Hints are used in two ways, if the server is configured to use them - see [below
   If hints are available, then the resulting match is checked against the list of hints and
   flagged with a `hintMismatch` issue if the match does not correspond to the hint.
 
+#### Loose matches
+
+Search requests may contain a `"loose": true` value.
+Loose searches will see if the supplied scientific name is a
+verncaular name or taxon identifier, as well as a proper scientific name.
+Search requests with parameters are always loose.
 
 ### Health Check
 
@@ -222,6 +228,7 @@ Most of these entries have suitable defaults.
 | | subgroups | | URL of the subgroups configuration |  | `file:///data/ala-namematching-service/config/subgroups.json` | 
 | | useHints | | Use hints supplied by the request to aid matching | | true |
 | | checkHints | | Check the resulting match against the supplied hints as a sanity check | | true |
+| | allowLoose | | Allow loose searches |  | true |
 
 The `groups.json` file is a list of common names for taxa, eg.
 

--- a/README.md
+++ b/README.md
@@ -212,10 +212,21 @@ Hints are used in two ways, if the server is configured to use them - see [below
 
 #### Loose matches
 
+Generally, the scientificName attribute is assumed to be a scientific name.
+However, some sources of information may also provide a name that is either
+a vernacular name or the taxon identifier associated with a specific taxon.
+This sort of search is termed a *loose* search.
+
 Search requests may contain a `"loose": true` value.
-Loose searches will see if the supplied scientific name is a
-verncaular name or taxon identifier, as well as a proper scientific name.
-Search requests with parameters are always loose.
+Loose searches will see if the supplied `scientificName` value is 
+actually a  verncaular name or taxon identifier, as well as a normal scientific name.
+
+The loose parameter is only used by the search `POST` request, where it
+can be specified as part of the request body.
+Search requests that use `GET` requests and URL parameters are always loose.
+
+A server must be configured to honour loose requests.
+See [below](#configuration).
 
 ### Health Check
 
@@ -240,7 +251,7 @@ Most of these entries have suitable defaults.
 | | subgroups | | URL of the subgroups configuration |  | `file:///data/ala-namematching-service/config/subgroups.json` | 
 | | useHints | | Use hints supplied by the request to aid matching | | true |
 | | checkHints | | Check the resulting match against the supplied hints as a sanity check | | true |
-| | allowLoose | | Allow loose searches |  | true |
+| | allowLoose | | Allow [loose](#loose-matches) searches |  | true |
 
 The `groups.json` file is a list of common names for taxa, eg.
 

--- a/core/src/main/java/au/org/ala/names/ws/api/NameSearch.java
+++ b/core/src/main/java/au/org/ala/names/ws/api/NameSearch.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonDeserialize(builder = NameSearch.NameSearchBuilder.class)
 @Value
 @Builder
@@ -157,6 +157,10 @@ public class NameSearch {
         notes = "http://rs.tdwg.org/dwc/terms/vernacularName"
     )
     private Map<String, List<String>> hints;
+    @ApiModelProperty(
+        value = "Allow a loose search. Loose searches will treat the scientific name as a vernacular name or a taxon identifier if the name cannot be found."
+    )
+    private boolean loose;
 
     /**
      * Get a version of this that has been normalised.
@@ -191,6 +195,7 @@ public class NameSearch {
                         k -> this.hints.get(k).stream().map(v -> NORMALISER.normalise(v)).collect(Collectors.toList()))
                     )
             )
+            .loose(this.loose)
             .build();
     }
 

--- a/server/src/main/java/au/org/ala/names/ws/core/NameSearchConfiguration.java
+++ b/server/src/main/java/au/org/ala/names/ws/core/NameSearchConfiguration.java
@@ -31,6 +31,8 @@ public class NameSearchConfiguration {
     /** Use hints to confirm the matching result (true by default) */
     @JsonProperty
     private boolean checkHints = true;
+    /** Allow loose searching on taxon identifier and vernacular name in place of scientific name, if requested */
+    private boolean allowLoose = true;
     /** The cache configuration */
     @JsonProperty
     private DataCacheConfiguration cache = DataCacheConfiguration.builder().build();

--- a/server/src/test/java/au/org/ala/names/ws/resources/NameSearchResourceTest.java
+++ b/server/src/test/java/au/org/ala/names/ws/resources/NameSearchResourceTest.java
@@ -123,6 +123,47 @@ public class NameSearchResourceTest {
 
 
     @Test
+    public void testSearchByClassification7() throws Exception {
+        NameSearch search = NameSearch.builder().genus("Osphranter").specificEpithet("rufus").loose(false).build();
+        NameUsageMatch match = this.resource.match(search);
+        assertTrue(match.isSuccess());
+        assertEquals("Osphranter rufus", match.getScientificName());
+        assertEquals("Animalia", match.getKingdom());
+        assertEquals("Osphranter", match.getGenus());
+        assertEquals(Collections.singletonList("noIssue"), match.getIssues());
+    }
+
+    @Test
+    public void testSearchByClassification8() throws Exception {
+        NameSearch search = NameSearch.builder().scientificName("Blue gum").loose(false).build();
+        NameUsageMatch match = this.resource.match(search);
+        assertFalse(match.isSuccess());
+    }
+
+    @Test
+    public void testSearchByClassification9() throws Exception {
+        NameSearch search = NameSearch.builder().scientificName("Splendid Telopea").loose(true).build();
+        NameUsageMatch match = this.resource.match(search);
+        assertTrue(match.isSuccess());
+        assertEquals("Telopea speciosissima", match.getScientificName());
+        assertEquals("Plantae", match.getKingdom());
+        assertEquals("vernacularMatch", match.getMatchType());
+        assertEquals(Collections.singletonList("noIssue"), match.getIssues());
+    }
+
+    @Test
+    public void testSearchByClassification10() throws Exception {
+        NameSearch search = NameSearch.builder().scientificName("https://id.biodiversity.org.au/node/apni/5272169").loose(true).build();
+        NameUsageMatch match = this.resource.match(search);
+        assertTrue(match.isSuccess());
+        assertEquals("Eucalyptus globulus", match.getScientificName());
+        assertEquals("https://id.biodiversity.org.au/node/apni/5272169", match.getTaxonConceptID());
+        assertEquals("taxonIdMatch", match.getMatchType());
+        assertEquals(Collections.singletonList("noIssue"), match.getIssues());
+    }
+
+
+    @Test
     public void testHomonym1() throws Exception {
         NameSearch search = NameSearch.builder().scientificName("Thalia").build();
         NameUsageMatch match = this.resource.match(search);


### PR DESCRIPTION
If requested and configured, check the scientific name to see if it is a vernacular name or taxon identifier.