### PR TITLE
Proposed fix for issue #52

### DIFF
--- a/server/src/main/java/au/org/ala/names/ws/core/SpeciesGroup.java
+++ b/server/src/main/java/au/org/ala/names/ws/core/SpeciesGroup.java
@@ -4,7 +4,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
 
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @JsonDeserialize(builder = SpeciesGroup.SpeciesGroupBuilder.class)
 @Builder
@@ -22,11 +23,37 @@ public class SpeciesGroup {
      * Determines whether the supplied lft value represents a species from this group/
      * Relies on the excluded values coming first in the lftRgtValues array
      */
-    Boolean isPartOfGroup(Integer lft){
+    Boolean isPartOfGroup(Integer lft) {
 
-        for (LftRgtValues lftRgtValue : lftRgtValues){
+        for (LftRgtValues lftRgtValue : lftRgtValues) {
             if (lft >= lftRgtValue.lft && lft < lftRgtValue.rgt)
                 return lftRgtValue.tobeIncluded;
+        }
+        return false;
+    }
+
+    /**
+     * Test to see if two species groups overlap in range.
+     * <p>
+     * We do this by testing the end points of each set of lr-values and seeing if
+     * there is an overlap.
+     * </p>
+     *
+     * @param other The other species group.
+     *
+     * @return True if at least one LR-pair in each group overlap.
+     */
+    public boolean overlaps(SpeciesGroup other) {
+        return this.overlaps1(other) || other.overlaps1(this);
+    }
+
+    // Simple one dimensional overlap test
+    private boolean overlaps1(SpeciesGroup other) {
+        for (LftRgtValues lr: this.lftRgtValues) {
+            if (this.isPartOfGroup(lr.lft) && other.isPartOfGroup(lr.lft))
+                return true;
+            if (this.isPartOfGroup(lr.rgt) && other.isPartOfGroup(lr.rgt)) // Occurs when exclusion is present
+                return true;
         }
         return false;
     }

--- a/server/src/main/resources/groups.json
+++ b/server/src/main/resources/groups.json
@@ -1,148 +1,199 @@
-[{
-  "name": "Animals",
-  "rank": "kingdom",
-  "included": ["Animalia"],
-  "excluded": []
-},
+[
+  {
+    "name": "Animals",
+    "rank": "kingdom",
+    "included": [
+      "Animalia"
+    ],
+    "excluded": []
+  },
   {
     "name": "Mammals",
     "rank": "classs",
-    "included": ["Mammalia"],
+    "included": [
+      "Mammalia"
+    ],
     "excluded": [],
     "parent": "Animals"
   },
   {
     "name": "Birds",
     "rank": "classs",
-    "included": ["Aves"],
+    "included": [
+      "Aves"
+    ],
     "excluded": [],
     "parent": "Animals"
   },
   {
     "name": "Reptiles",
     "rank": "classs",
-    "included": ["Reptilia"],
+    "included": [
+      "Reptilia"
+    ],
     "excluded": [],
     "parent": "Animals"
   },
   {
     "name": "Amphibians",
     "rank": "classs",
-    "included": ["Amphibia"],
+    "included": [
+      "Amphibia"
+    ],
     "excluded": [],
     "parent": "Animals"
   },
   {
     "name": "Fishes",
     "rank": "classs",
-    "included": ["Agnatha", "Chondrichthyes", "Osteichthyes", "Actinopterygii", "Sarcopterygii"],
+    "included": [
+      "Agnatha",
+      "Chondrichthyes",
+      "Osteichthyes",
+      "Actinopterygii",
+      "Sarcopterygii"
+    ],
     "excluded": [],
     "parent": "Animals"
   },
   {
     "name": "Molluscs",
     "rank": "phylum",
-    "included": ["Mollusca"],
+    "included": [
+      "Mollusca"
+    ],
     "excluded": [],
     "parent": "Animals"
   },
   {
     "name": "Arthropods",
     "rank": "phylum",
-    "included": ["Arthropoda"],
+    "included": [
+      "Arthropoda"
+    ],
     "excluded": [],
     "parent": "Animals"
   },
   {
     "name": "Crustaceans",
     "rank": "classs",
-    "included": ["Branchiopoda", "Remipedia", "Maxillopoda", "Ostracoda", "Malacostraca"],
+    "included": [
+      "Branchiopoda",
+      "Remipedia",
+      "Maxillopoda",
+      "Ostracoda",
+      "Malacostraca"
+    ],
     "excluded": [],
     "parent": "Arthropods"
   },
   {
     "name": "Insects",
     "rank": "classs",
-    "included": ["Insecta"],
+    "included": [
+      "Insecta"
+    ],
     "excluded": [],
     "parent": "Arthropods"
   },
   {
     "name": "Plants",
     "rank": "kingdom",
-    "included": ["Plantae"],
+    "included": [
+      "Plantae"
+    ],
     "excluded": []
   },
   {
     "name": "Bryophytes",
     "rank": "phylum",
-    "included": ["Bryophyta", "Marchantiophyta", "Anthocerotophyta"],
+    "included": [
+      "Bryophyta",
+      "Marchantiophyta",
+      "Anthocerotophyta"
+    ],
     "excluded": []
   },
   {
-    "name": "Gymnosperms",
+    "name": "Conifers, Cycads",
     "rank": "subclass",
-    "included": ["Pinidae", "Cycadidae"],
+    "included": [
+      "Pinidae",
+      "Cycadidae"
+    ],
     "excluded": [],
     "parent": "Plants"
   },
   {
-    "name": "FernsAndAllies",
+    "name": "Ferns and allies",
     "rank": "subclass",
-    "included": ["Equisetidae", "Lycopodiidae", "Marattiidae", "Ophioglossidae", "Polypodiidae", "Psilotidae"],
+    "included": [
+      "Equisetidae",
+      "Lycopodiidae",
+      "Marattiidae",
+      "Ophioglossidae",
+      "Polypodiidae",
+      "Psilotidae"
+    ],
     "excluded": [],
     "parent": "Plants"
   },
   {
-    "name": "Angiosperms",
+    "name": "Flowering plants",
     "rank": "subclass",
-    "included": ["Magnoliidae"],
+    "included": [
+      "Magnoliidae"
+    ],
     "excluded": [],
     "parent": "Plants"
-  },
-  {
-    "name": "Monocots",
-    "rank": "superorder",
-    "included": ["Lilianae"],
-    "excluded": [],
-    "parent": "Angiosperms"
-  },
-  {
-    "name": "Dicots",
-    "rank": "subclass",
-    "included": ["Magnoliidae"],
-    "excluded": ["Lilianae"],
-    "parent": "Angiosperms"
   },
   {
     "name": "Fungi",
     "rank": "kingdom",
-    "included": ["Fungi"],
+    "included": [
+      "Fungi"
+    ],
     "excluded": []
   },
   {
     "name": "Chromista",
     "rank": "kingdom",
-    "included": ["Chromista"],
+    "included": [
+      "Chromista"
+    ],
     "excluded": []
   },
   {
     "name": "Protozoa",
     "rank": "kingdom",
-    "included": ["Protozoa"],
+    "included": [
+      "Protozoa"
+    ],
     "excluded": []
   },
   {
     "name": "Bacteria",
     "rank": "kingdom",
-    "included": ["Bacteria"],
+    "included": [
+      "Bacteria"
+    ],
     "excluded": []
   },
   {
     "name": "Algae",
     "rank": "phylum",
-    "included": ["Bacillariophyta", "Chlorophyta", "Cyanidiophyta", "Prasinophyta", "Rhodophyta",
-      "Cryptophyta", "Ochrophyta", "Sagenista", "Cercozoa", "Euglenozoa", "Cyanobacteria"
+    "included": [
+      "Bacillariophyta",
+      "Chlorophyta",
+      "Cyanidiophyta",
+      "Prasinophyta",
+      "Rhodophyta",
+      "Cryptophyta",
+      "Ochrophyta",
+      "Sagenista",
+      "Cercozoa",
+      "Euglenozoa",
+      "Cyanobacteria"
     ],
     "excluded": []
   }

--- a/server/src/main/resources/subgroups.json
+++ b/server/src/main/resources/subgroups.json
@@ -1,625 +1,893 @@
 [
   {
-    "speciesGroup": "Mammals",
-    "taxonRank": "order",
+    "parent": "Mammals",
+    "rank": "order",
     "taxa": [
       {
-        "name": "DASYUROMORPHIA",
-        "common": "Carnivorous Marsupials"
+        "name": "Carnivorous Marsupials",
+        "included": [
+          "DASYUROMORPHIA"
+        ]
       },
       {
-        "name": "DIPROTODONTIA",
-        "common": "Herbivorous Marsupials"
+        "name": "Herbivorous Marsupials",
+        "included": [
+          "DIPROTODONTIA"
+        ]
       },
       {
-        "name": "NOTORYCTEMORPHIA",
-        "common": "Marsupial Moles"
+        "name": "Marsupial Moles",
+        "included": [
+          "NOTORYCTEMORPHIA"
+        ]
       },
       {
-        "name": "PERAMELEMORPHIA",
-        "common": "Bandicoots, Bilbies"
+        "name": "Bandicoots, Bilbies",
+        "included": [
+          "PERAMELEMORPHIA"
+        ]
       },
       {
-        "name": "MONOTREMATA",
-        "common": "Monotremes"
+        "name": "Monotremes",
+        "included": [
+          "MONOTREMATA"
+        ]
       },
       {
-        "name": "ARTIODACTYLA",
-        "common": "Even-toed hoofed"
+        "name": "Even-toed hoofed",
+        "included": [
+          "ARTIODACTYLA"
+        ]
       },
       {
-        "name": "CARNIVORA",
-        "common": "Carnivores"
+        "name": "Carnivores",
+        "included": [
+          "CARNIVORA"
+        ]
       },
       {
-        "name": "CETACEA",
-        "common": "Dolphins, Porpoises, Whales"
+        "name": "Dolphins, Porpoises, Whales",
+        "included": [
+          "CETACEA"
+        ]
       },
       {
-        "name": "CHIROPTERA",
-        "common": "Bats"
+        "name": "Bats",
+        "included": [
+          "CHIROPTERA"
+        ]
       },
       {
-        "name": "INSECTIVORA",
-        "common": "Shrews, Hedgehogs"
+        "name": "Shrews, Hedgehogs",
+        "included": [
+          "INSECTIVORA"
+        ]
       },
       {
-        "name": "LAGOMORPHA",
-        "common": "Hares, Pikas, Rabbits"
+        "name": "Hares, Pikas, Rabbits",
+        "included": [
+          "LAGOMORPHA"
+        ]
       },
       {
-        "name": "PERRISODACTYLA",
-        "common": "Odd-toed hoofed"
+        "name": "Odd-toed hoofed",
+        "included": [
+          "PERRISODACTYLA"
+        ]
       },
       {
-        "name": "RODENTIA",
-        "common": "Rodents"
+        "name": "Rodents",
+        "included": [
+          "RODENTIA"
+        ]
       },
       {
-        "name": "SIRENIA",
-        "common": "Dugongs, Manatees, Sea Cows"
+        "name": "Dugongs, Manatees, Sea Cows",
+        "included": [
+          "SIRENIA"
+        ]
       }
     ]
   },
   {
-    "speciesGroup": "Birds",
-    "taxonRank": "order",
+    "parent": "Birds",
+    "rank": "order",
     "taxa": [
       {
-        "name": "ANSERIFORMES",
-        "common": "Ducks, Geese, Swans"
+        "name": "Ducks, Geese, Swans",
+        "included": [
+          "ANSERIFORMES"
+        ]
       },
       {
-        "name": "APODIFORMES",
-        "common": "Hummingbirds, Swifts"
+        "name": "Hummingbirds, Swifts",
+        "included": [
+          "APODIFORMES"
+        ]
       },
       {
-        "name": "CAPRIMULGIFORMES",
-        "common": "Nightjars, Frogmouths, Potoos"
+        "name": "Nightjars, Frogmouths, Potoos",
+        "included": [
+          "CAPRIMULGIFORMES"
+        ]
       },
       {
-        "name": "CHARADRIIFORMES",
-        "common": "Waders, Gulls, Auks"
+        "name": "Waders, Gulls, Auks",
+        "included": [
+          "CHARADRIIFORMES"
+        ]
       },
       {
-        "name": "CICONIIFORMES",
-        "common": "Bitterns, Ibises"
+        "name": "Bitterns, Ibises",
+        "included": [
+          "CICONIIFORMES"
+        ]
       },
       {
-        "name": "COLUMBIFORMES",
-        "common": "Doves"
+        "name": "Doves",
+        "included": [
+          "COLUMBIFORMES"
+        ]
       },
       {
-        "name": "CORACIIFORMES",
-        "common": "Kingfishers"
+        "name": "Kingfishers",
+        "included": [
+          "CORACIIFORMES"
+        ]
       },
       {
-        "name": "CUCULIFORMES",
-        "common": "Cuckoos"
+        "name": "Cuckoos",
+        "included": [
+          "CUCULIFORMES"
+        ]
       },
       {
-        "name": "FALCONIFORMES",
-        "common": "Falcons"
+        "name": "Falcons",
+        "included": [
+          "FALCONIFORMES"
+        ]
       },
       {
-        "name": "GALLIFORMES",
-        "common": "Fowls"
+        "name": "Fowls",
+        "included": [
+          "GALLIFORMES"
+        ]
       },
       {
-        "name": "GRUIFORMES",
-        "common": "Cranes"
+        "name": "Cranes",
+        "included": [
+          "GRUIFORMES"
+        ]
       },
       {
-        "name": "PASSERIFORMES",
-        "common": "Perching Birds"
+        "name": "Perching Birds",
+        "included": [
+          "PASSERIFORMES"
+        ]
       },
       {
-        "name": "PELECANIFORMES",
-        "common": "Large waterbirds"
+        "name": "Large waterbirds",
+        "included": [
+          "PELECANIFORMES"
+        ]
       },
       {
-        "name": "PHOENICOPTERIFORMES",
-        "common": "Flamingos"
+        "name": "Flamingos",
+        "included": [
+          "PHOENICOPTERIFORMES"
+        ]
       },
       {
-        "name": "PODICIPEDIFORMES",
-        "common": "Grebes"
+        "name": "Grebes",
+        "included": [
+          "PODICIPEDIFORMES"
+        ]
       },
       {
-        "name": "PROCELLARIIFORMES",
-        "common": "Petrels, Fulmars"
+        "name": "Petrels, Fulmars",
+        "included": [
+          "PROCELLARIIFORMES"
+        ]
       },
       {
-        "name": "PSITTACIFORMES",
-        "common": "Parrots"
+        "name": "Parrots",
+        "included": [
+          "PSITTACIFORMES"
+        ]
       },
       {
-        "name": "SPHENISCIFORMES",
-        "common": "Penguins"
+        "name": "Penguins",
+        "included": [
+          "SPHENISCIFORMES"
+        ]
       },
       {
-        "name": "STRIGIFORMES",
-        "common": "Owls"
+        "name": "Owls",
+        "included": [
+          "STRIGIFORMES"
+        ]
       },
       {
-        "name": "STRUTHIONIFORMES",
-        "common": "Ostriches"
+        "name": "Ostriches",
+        "included": [
+          "STRUTHIONIFORMES"
+        ]
       },
       {
-        "name": "TURNICIFORMES",
-        "common": "Buttonquails"
+        "name": "Buttonquails",
+        "included": [
+          "TURNICIFORMES"
+        ]
       }
     ]
   },
   {
-    "speciesGroup": "Insects and Spiders",
-    "taxonRank": "order",
+    "parent": "Insects and Spiders",
+    "rank": "order",
     "taxa": [
       {
-        "name": "ARCHAEOGNATHA",
-        "common": "Bristletails"
+        "name": "Bristletails",
+        "included": [
+          "ARCHAEOGNATHA"
+        ]
       },
       {
-        "name": "BLATTODEA",
-        "common": "Cockroaches, Termites"
+        "name": "Cockroaches, Termites",
+        "included": [
+          "BLATTODEA"
+        ]
       },
       {
-        "name": "COLEOPTERA",
-        "common": "Beetles"
+        "name": "Beetles",
+        "included": [
+          "COLEOPTERA"
+        ]
       },
       {
-        "name": "DERMAPTERA",
-        "common": "Earwigs"
+        "name": "Earwigs",
+        "included": [
+          "DERMAPTERA"
+        ]
       },
       {
-        "name": "DIPTERA",
-        "common": "Flies, Mosquitoes"
+        "name": "Flies, Mosquitoes",
+        "included": [
+          "DIPTERA"
+        ]
       },
       {
-        "name": "EMBIOPTERA",
-        "common": "Webspinners"
+        "name": "Webspinners",
+        "included": [
+          "EMBIOPTERA"
+        ]
       },
       {
-        "name": "EPHEMEROPTERA",
-        "common": "Mayflies, Shadlfies"
+        "name": "Mayflies, Shadlfies",
+        "included": [
+          "EPHEMEROPTERA"
+        ]
       },
       {
-        "name": "HEMIPTERA",
-        "common": "Cicadas, Aphids, Planthoppers, Leafhoppers, Shield Bugs"
+        "name": "Cicadas, Aphids, Planthoppers, Leafhoppers, Shield Bugs",
+        "included": [
+          "HEMIPTERA"
+        ]
       },
       {
-        "name": "HYMENOPTERA",
-        "common": "Wasps, Ants, Bees, Sawflies"
+        "name": "Wasps, Ants, Bees, Sawflies",
+        "included": [
+          "HYMENOPTERA"
+        ]
       },
       {
-        "name": "LEPIDOPTERA",
-        "common": "Butterflies, Moths"
+        "name": "Butterflies, Moths",
+        "included": [
+          "LEPIDOPTERA"
+        ]
       },
       {
-        "name": "MANTODEA",
-        "common": "Mantises"
+        "name": "Mantises",
+        "included": [
+          "MANTODEA"
+        ]
       },
       {
-        "name": "MECOPTERA",
-        "common": "Scorpionflies, Hangingflies"
+        "name": "Scorpionflies, Hangingflies",
+        "included": [
+          "MECOPTERA"
+        ]
       },
       {
-        "name": "MEGALOPTERA",
-        "common": "Alderflies, Dobsonflies, Fishflies"
+        "name": "Alderflies, Dobsonflies, Fishflies",
+        "included": [
+          "MEGALOPTERA"
+        ]
       },
       {
-        "name": "NEUROPTERA",
-        "common": "Lacewings, Mantidflies, Antlions"
+        "name": "Lacewings, Mantidflies, Antlions",
+        "included": [
+          "NEUROPTERA"
+        ]
       },
       {
-        "name": "ODONATA",
-        "common": "Dragonflies, Damselflies"
+        "name": "Dragonflies, Damselflies",
+        "included": [
+          "ODONATA"
+        ]
       },
       {
-        "name": "ORTHOPTERA",
-        "common": "Grasshoppers, Crickets, Locusts, Katydids, Weta, Lubber"
+        "name": "Grasshoppers, Crickets, Locusts, Katydids, Weta, Lubber",
+        "included": [
+          "ORTHOPTERA"
+        ]
       },
       {
-        "name": "PHASMIDA",
-        "common": "Stick Insects, Phasmids"
+        "name": "Stick Insects, Phasmids",
+        "included": [
+          "PHASMIDA"
+        ]
       },
       {
-        "name": "PHTHIRAPTERA",
-        "common": "Lice"
+        "name": "Lice",
+        "included": [
+          "PHTHIRAPTERA"
+        ]
       },
       {
-        "name": "PLECOPTERA",
-        "common": "Stoneflies"
+        "name": "Stoneflies",
+        "included": [
+          "PLECOPTERA"
+        ]
       },
       {
-        "name": "PSOCOPTERA",
-        "common": "Booklice, Barklice, Barkflies"
+        "name": "Booklice, Barklice, Barkflies",
+        "included": [
+          "PSOCOPTERA"
+        ]
       },
       {
-        "name": "SIPHONAPTERA",
-        "common": "Fleas"
+        "name": "Fleas",
+        "included": [
+          "SIPHONAPTERA"
+        ]
       },
       {
-        "name": "STREPSIPTERA",
-        "common": "Twisted-Wing Parasites"
+        "name": "Twisted-Wing Parasites",
+        "included": [
+          "STREPSIPTERA"
+        ]
       },
       {
-        "name": "THYSANOPTERA",
-        "common": "Thrips"
+        "name": "Thrips",
+        "included": [
+          "THYSANOPTERA"
+        ]
       },
       {
-        "name": "TRICHOPTERA",
-        "common": "Caddisflies, Sedge-flies or Rail-flies"
+        "name": "Caddisflies, Sedge-flies or Rail-flies",
+        "included": [
+          "TRICHOPTERA"
+        ]
       },
       {
-        "name": "ZORAPTERA",
-        "common": "Zorapterans"
+        "name": "Zorapterans",
+        "included": [
+          "ZORAPTERA"
+        ]
       },
       {
-        "name": "ZYGENTOMA",
-        "common": "Silverfish"
+        "name": "Silverfish",
+        "included": [
+          "ZYGENTOMA"
+        ]
       },
       {
-        "name": "ARANEAE",
-        "common": "Spiders"
+        "name": "Spiders",
+        "included": [
+          "ARANEAE"
+        ]
       }
     ]
   },
   {
-    "speciesGroup": "Amphibians",
-    "taxonRank": "family",
+    "parent": "Amphibians",
+    "rank": "family",
     "taxa": [
       {
-        "name": "BUFONIDAE",
-        "common": "True Toads"
+        "name": "True Toads",
+        "included": [
+          "BUFONIDAE"
+        ]
       },
       {
-        "name": "HYLIDAE",
-        "common": "Tree Frogs"
+        "name": "Tree Frogs",
+        "included": [
+          "HYLIDAE"
+        ]
       },
       {
-        "name": "MICROHYLIDAE",
-        "common": "Narrow-Mouthed Frogs"
+        "name": "Narrow-Mouthed Frogs",
+        "included": [
+          "MICROHYLIDAE"
+        ]
       },
       {
-        "name": "MYOBATRACHIDAE",
-        "common": "Australian Ground Frogs"
+        "name": "Australian Ground Frogs",
+        "included": [
+          "MYOBATRACHIDAE"
+        ]
       },
       {
-        "name": "RANIDAE",
-        "common": "True Frogs"
+        "name": "True Frogs",
+        "included": [
+          "RANIDAE"
+        ]
       }
     ]
   },
   {
-    "speciesGroup": "Reptiles",
-    "taxonRank": "order",
+    "parent": "Reptiles",
+    "rank": "order",
     "taxa": [
       {
-        "name": "CROCODYLIA",
-        "common": "Crocodiles"
+        "name": "Crocodiles",
+        "included": [
+          "CROCODYLIA"
+        ]
       },
       {
-        "name": "SQUAMATA",
-        "common": "Lizards, Snakes"
+        "name": "Lizards, Snakes",
+        "included": [
+          "SQUAMATA"
+        ]
       },
       {
-        "name": "TESTUDINES",
-        "common": "Tortoises, Turtles, Terrapins"
+        "name": "Tortoises, Turtles, Terrapins",
+        "included": [
+          "TESTUDINES"
+        ]
       }
     ]
   },
   {
-    "speciesGroup": "Fish",
-    "taxonRank": "order",
+    "parent": "Fish",
+    "rank": "order",
     "taxa": [
       {
-        "name": "MYXINIFORMES",
-        "common": "Hagfishes"
+        "name": "Hagfishes",
+        "included": [
+          "MYXINIFORMES"
+        ]
       },
       {
-        "name": "CARCHARHINIFORMES",
-        "common": "Ground Sharks"
+        "name": "Ground Sharks",
+        "included": [
+          "CARCHARHINIFORMES"
+        ]
       },
       {
-        "name": "HETERODONTIFORMES",
-        "common": "Bullhead Sharks"
+        "name": "Bullhead Sharks",
+        "included": [
+          "HETERODONTIFORMES"
+        ]
       },
       {
-        "name": "HEXANCHIFORMES",
-        "common": "Cow Sharks"
+        "name": "Cow Sharks",
+        "included": [
+          "HEXANCHIFORMES"
+        ]
       },
       {
-        "name": "LAMNIFORMES",
-        "common": "Mackerel Sharks"
+        "name": "Mackerel Sharks",
+        "included": [
+          "LAMNIFORMES"
+        ]
       },
       {
-        "name": "MYLIOBATIFORMES",
-        "common": "Batoids"
+        "name": "Batoids",
+        "included": [
+          "MYLIOBATIFORMES"
+        ]
       },
       {
-        "name": "ORECTOLOBIFORMES",
-        "common": "Carpet Sharks"
+        "name": "Carpet Sharks",
+        "included": [
+          "ORECTOLOBIFORMES"
+        ]
       },
       {
-        "name": "PRISTIFORMES",
-        "common": "Sawfish"
+        "name": "Sawfish",
+        "included": [
+          "PRISTIFORMES"
+        ]
       },
       {
-        "name": "PRISTIOPHORIFORMES",
-        "common": "Saw Sharks"
+        "name": "Saw Sharks",
+        "included": [
+          "PRISTIOPHORIFORMES"
+        ]
       },
       {
-        "name": "RAJIFORMES",
-        "common": "Softnose Skates"
+        "name": "Softnose Skates",
+        "included": [
+          "RAJIFORMES"
+        ]
       },
       {
-        "name": "RHINOBATIFORMES",
-        "common": "Guitarfish"
+        "name": "Guitarfish",
+        "included": [
+          "RHINOBATIFORMES"
+        ]
       },
       {
-        "name": "SQUALIFORMES",
-        "common": "Dogfish Sharks"
+        "name": "Dogfish Sharks",
+        "included": [
+          "SQUALIFORMES"
+        ]
       },
       {
-        "name": "SQUATINIFORMES",
-        "common": "Angel Sharks"
+        "name": "Angel Sharks",
+        "included": [
+          "SQUATINIFORMES"
+        ]
       },
       {
-        "name": "TORPEDINIFORMES",
-        "common": "Electric Rays"
+        "name": "Electric Rays",
+        "included": [
+          "TORPEDINIFORMES"
+        ]
       },
       {
-        "name": "CHIMAERIFORMES",
-        "common": "Chimaeras"
+        "name": "Chimaeras",
+        "included": [
+          "CHIMAERIFORMES"
+        ]
       },
       {
-        "name": "CERATODONTIFORMES",
-        "common": "Lungfish"
+        "name": "Lungfish",
+        "included": [
+          "CERATODONTIFORMES"
+        ]
       },
       {
-        "name": "CLUPEIFORMES",
-        "common": "Anchovies "
+        "name": "Anchovies ",
+        "included": [
+          "CLUPEIFORMES"
+        ]
       },
       {
-        "name": "ALBULIFORMES",
-        "common": "Bonefishes"
+        "name": "Bonefishes",
+        "included": [
+          "ALBULIFORMES"
+        ]
       },
       {
-        "name": "ANGUILLIFORMES",
-        "common": "Eels"
+        "name": "Eels",
+        "included": [
+          "ANGUILLIFORMES"
+        ]
       },
       {
-        "name": "ELOPIFORMES",
-        "common": "Tarpons"
+        "name": "Tarpons",
+        "included": [
+          "ELOPIFORMES"
+        ]
       },
       {
-        "name": "NOTACANTHIFORMES",
-        "common": "Spiny Eels"
+        "name": "Spiny Eels",
+        "included": [
+          "NOTACANTHIFORMES"
+        ]
       },
       {
-        "name": "SACCOPHARYNGIFORMES",
-        "common": "Sackpharynx Fishes"
+        "name": "Sackpharynx Fishes",
+        "included": [
+          "SACCOPHARYNGIFORMES"
+        ]
       },
       {
-        "name": "ATHERINIFORMES",
-        "common": "Rainbow Fishes"
+        "name": "Rainbow Fishes",
+        "included": [
+          "ATHERINIFORMES"
+        ]
       },
       {
-        "name": "BELONIFORMES",
-        "common": "Halfbeeks"
+        "name": "Halfbeeks",
+        "included": [
+          "BELONIFORMES"
+        ]
       },
       {
-        "name": "BERYCIFORMES",
-        "common": "Ray-finned fishes"
+        "name": "Ray-finned fishes",
+        "included": [
+          "BERYCIFORMES"
+        ]
       },
       {
-        "name": "CYPRINODONTIFORMES",
-        "common": "Killifishes"
+        "name": "Killifishes",
+        "included": [
+          "CYPRINODONTIFORMES"
+        ]
       },
       {
-        "name": "GASTEROSTEIFORMES",
-        "common": "Dragonfishes"
+        "name": "Dragonfishes",
+        "included": [
+          "GASTEROSTEIFORMES"
+        ]
       },
       {
-        "name": "MUGILIFORMES",
-        "common": "Mullet fish"
+        "name": "Mullet fish",
+        "included": [
+          "MUGILIFORMES"
+        ]
       },
       {
-        "name": "PERCIFORMES",
-        "common": "Perch-like Fishes"
+        "name": "Perch-like Fishes",
+        "included": [
+          "PERCIFORMES"
+        ]
       },
       {
-        "name": "PLEURONECTIFORMES",
-        "common": "Flatfishes"
+        "name": "Flatfishes",
+        "included": [
+          "PLEURONECTIFORMES"
+        ]
       },
       {
-        "name": "SCORPAENIFORMES",
-        "common": "Scorpion Fishes, Sculpins"
+        "name": "Scorpion Fishes, Sculpins",
+        "included": [
+          "SCORPAENIFORMES"
+        ]
       },
       {
-        "name": "STEPHANOBERYCIFORMES",
-        "common": "Deep-sea ray-finned fishes"
+        "name": "Deep-sea ray-finned fishes",
+        "included": [
+          "STEPHANOBERYCIFORMES"
+        ]
       },
       {
-        "name": "SYNBRANCHIFORMES",
-        "common": "Swamp Eels"
+        "name": "Swamp Eels",
+        "included": [
+          "SYNBRANCHIFORMES"
+        ]
       },
       {
-        "name": "TETRAODONTIFORMES",
-        "common": "Cowfishes"
+        "name": "Cowfishes",
+        "included": [
+          "TETRAODONTIFORMES"
+        ]
       },
       {
-        "name": "ZEIFORMES",
-        "common": "Boarfishes"
+        "name": "Boarfishes",
+        "included": [
+          "ZEIFORMES"
+        ]
       },
       {
-        "name": "AULOPIFORMES",
-        "common": "Marine ray-finned fish"
+        "name": "Marine ray-finned fish",
+        "included": [
+          "AULOPIFORMES"
+        ]
       },
       {
-        "name": "LAMPRIDIFORMES",
-        "common": "Opahs"
+        "name": "Opahs",
+        "included": [
+          "LAMPRIDIFORMES"
+        ]
       },
       {
-        "name": "CYPRINIFORMES",
-        "common": "Minnows"
+        "name": "Minnows",
+        "included": [
+          "CYPRINIFORMES"
+        ]
       },
       {
-        "name": "GONORHYNCHIFORMES",
-        "common": "Milkfishes"
+        "name": "Milkfishes",
+        "included": [
+          "GONORHYNCHIFORMES"
+        ]
       },
       {
-        "name": "SILURIFORMES",
-        "common": "Catfishes"
+        "name": "Catfishes",
+        "included": [
+          "SILURIFORMES"
+        ]
       },
       {
-        "name": "BATRACHOIDIFORMES",
-        "common": "Batrachoidiforms"
+        "name": "Batrachoidiforms",
+        "included": [
+          "BATRACHOIDIFORMES"
+        ]
       },
       {
-        "name": "GADIFORMES",
-        "common": "Cods"
+        "name": "Cods",
+        "included": [
+          "GADIFORMES"
+        ]
       },
       {
-        "name": "LOPHIIFORMES",
-        "common": "Anglerfishes"
+        "name": "Anglerfishes",
+        "included": [
+          "LOPHIIFORMES"
+        ]
       },
       {
-        "name": "OPHIDIIFORMES",
-        "common": "Ophidiiforms"
+        "name": "Ophidiiforms",
+        "included": [
+          "OPHIDIIFORMES"
+        ]
       },
       {
-        "name": "POLYMIXIIFORMES",
-        "common": "Beardfishes"
+        "name": "Beardfishes",
+        "included": [
+          "POLYMIXIIFORMES"
+        ]
       },
       {
-        "name": "ARGENTINIFORMES",
-        "common": "Baldfishes,Tubeshoulders"
+        "name": "Baldfishes, Tubeshoulders",
+        "included": [
+          "ARGENTINIFORMES"
+        ]
       },
       {
-        "name": "SALMONIFORMES",
-        "common": "Salmons"
+        "name": "Salmons",
+        "included": [
+          "SALMONIFORMES"
+        ]
       },
       {
-        "name": "MYCTOPHIFORMES",
-        "common": "Latern Fishes, Neoscopelids"
+        "name": "Latern Fishes, Neoscopelids",
+        "included": [
+          "MYCTOPHIFORMES"
+        ]
       },
       {
-        "name": "ATELEOPODIFORMES",
-        "common": "Jellynose Fishes"
+        "name": "Jellynose Fishes",
+        "included": [
+          "ATELEOPODIFORMES"
+        ]
       },
       {
-        "name": "STOMIIFORMES",
-        "common": "Deep-sea ray-finned fishes"
+        "name": "Deep-sea ray-finned fishes",
+        "included": [
+          "STOMIIFORMES"
+        ]
       },
       {
-        "name": "OSTEOGLOSSIFORMES",
-        "common": "Bonytongues"
+        "name": "Bonytongues",
+        "included": [
+          "OSTEOGLOSSIFORMES"
+        ]
       }
     ]
   },
   {
-    "speciesGroup": "Molluscs",
-    "taxonRank": "class",
+    "parent": "Molluscs",
+    "rank": "class",
     "taxa": [
       {
-        "name": "APLACOPHORA",
-        "common": "Solenogasters"
+        "name": "Solenogasters",
+        "included": [
+          "APLACOPHORA"
+        ]
       },
       {
-        "name": "BIVALVIA",
-        "common": "Mussels, Clams"
+        "name": "Mussels, Clams",
+        "included": [
+          "BIVALVIA"
+        ]
       },
       {
-        "name": "CEPHALOPODA",
-        "common": "Cuttlefish"
+        "name": "Cuttlefish",
+        "included": [
+          "CEPHALOPODA"
+        ]
       },
       {
-        "name": "GASTROPODA",
-        "common": "Gastropods, Slugs, Snails"
+        "name": "Gastropods, Slugs, Snails",
+        "included": [
+          "GASTROPODA"
+        ]
       },
       {
-        "name": "POLYPLACOPHORA",
-        "common": "Chitons"
+        "name": "Chitons",
+        "included": [
+          "POLYPLACOPHORA"
+        ]
       },
       {
-        "name": "SCAPHOPODA",
-        "common": "Tooth Shells"
+        "name": "Tooth Shells",
+        "included": [
+          "SCAPHOPODA"
+        ]
       }
     ]
   },
   {
-    "speciesGroup": "Crustaceans",
-    "taxonRank": "class",
+    "parent": "Crustaceans",
+    "rank": "class",
     "taxa": [
       {
-        "name": "BRANCHIOPODA",
-        "common": "Fairy shrimp, Clam shrimp"
+        "name": "Fairy shrimp, Clam shrimp",
+        "included": [
+          "BRANCHIOPODA"
+        ]
       },
       {
-        "name": "MALACOSTRACA",
-        "common": "Crabs, Lobsters"
+        "name": "Crabs, Lobsters",
+        "included": [
+          "MALACOSTRACA"
+        ]
       },
       {
-        "name": "MAXILLOPODA",
-        "common": "Barnacles, Copepods"
+        "name": "Barnacles, Copepods",
+        "included": [
+          "MAXILLOPODA"
+        ]
       },
       {
-        "name": "OSTRACODA",
-        "common": "Seed shrimp"
+        "name": "Seed shrimp",
+        "included": [
+          "OSTRACODA"
+        ]
       }
     ]
   },
   {
-    "speciesGroup": "Plants",
-    "facetName": "species_group",
+    "parent": "Flowering Plants",
     "taxa": [
       {
         "name": "Monocots",
-        "common": "Monocots"
+        "rank": "superorder",
+        "included": [
+          "Lilianae"
+        ]
       },
       {
         "name": "Dicots",
-        "common": "Dicots"
-      },
-      {
-        "name": "Angiosperms",
-        "common": "Flowering plants"
-      },
-      {
-        "name": "FernsAndAllies",
-        "common": "Ferns and Allies"
-      },
-      {
-        "name": "Gymnosperms",
-        "common": "Conifers, Cycads"
+        "rank": "subclass",
+        "included": [
+          "Magnoliidae"
+        ],
+        "excluded": [
+          "Lilianae"
+        ]
       }
     ]
   },
   {
-    "speciesGroup": "Fungi",
-    "taxonRank": "phylum",
+    "parent": "Fungi",
+    "rank": "phylum",
     "taxa": [
       {
-        "name": "Ascomycota",
-        "common": "Asco's"
+        "name": "Asco's",
+        "included": [
+          "Ascomycota"
+        ]
       },
       {
-        "name": "Basidiomycota",
-        "common": "Basidio's"
+        "name": "Basidio's",
+        "included": [
+          "Basidiomycota"
+        ]
       },
       {
-        "name": "Chytridiomycota",
-        "common": "Chytrids"
+        "name": "Chytrids",
+        "included": [
+          "Chytridiomycota"
+        ]
       },
       {
-        "name": "Zygomycota",
-        "common": "Zygomycetes"
+        "name": "Zygomycetes",
+        "included": [
+          "Zygomycota"
+        ]
       },
       {
         "name": "Glomeromycota",
-        "common": "Glomeromycota"
+        "included": [
+          "Glomeromycota"
+        ]
       }
     ]
   }

--- a/server/src/test/java/au/org/ala/names/ws/core/SpeciesGroupTest.java
+++ b/server/src/test/java/au/org/ala/names/ws/core/SpeciesGroupTest.java
@@ -1,0 +1,264 @@
+package au.org.ala.names.ws.core;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class SpeciesGroupTest {
+
+    @Test
+    public void isPartOfGroup1() {
+        SpeciesGroup group = SpeciesGroup.builder()
+                .name("Test 1")
+                .rank("species")
+                .parent("Animals")
+                .lftRgtValues(Arrays.asList(
+                        LftRgtValues.builder().lft(100).rgt(400).tobeIncluded(true).build()
+                ))
+                .build();
+        assertTrue(group.isPartOfGroup(200));
+        assertTrue(group.isPartOfGroup(100));
+        assertTrue(group.isPartOfGroup(300));
+        assertFalse(group.isPartOfGroup(500));
+    }
+
+    @Test
+    public void isPartOfGroup2() {
+        SpeciesGroup group = SpeciesGroup.builder()
+                .name("Test 1")
+                .rank("species")
+                .parent("Animals")
+                .lftRgtValues(Arrays.asList(
+                        LftRgtValues.builder().lft(150).rgt(250).tobeIncluded(false).build(),
+                        LftRgtValues.builder().lft(100).rgt(400).tobeIncluded(true).build()
+                ))
+                .build();
+        assertFalse(group.isPartOfGroup(200));
+        assertTrue(group.isPartOfGroup(100));
+        assertTrue(group.isPartOfGroup(300));
+        assertFalse(group.isPartOfGroup(500));
+    }
+
+    @Test
+    public void isPartOfGroup3() {
+        SpeciesGroup group = SpeciesGroup.builder()
+                .name("Test 1")
+                .rank("species")
+                .parent("Animals")
+                .lftRgtValues(Arrays.asList(
+                        LftRgtValues.builder().lft(150).rgt(250).tobeIncluded(false).build(),
+                        LftRgtValues.builder().lft(100).rgt(400).tobeIncluded(true).build(),
+                        LftRgtValues.builder().lft(450).rgt(500).tobeIncluded(true).build()
+                ))
+                .build();
+        assertFalse(group.isPartOfGroup(200));
+        assertTrue(group.isPartOfGroup(100));
+        assertTrue(group.isPartOfGroup(300));
+        assertFalse(group.isPartOfGroup(425));
+        assertFalse(group.isPartOfGroup(500));
+    }
+
+    @Test
+    public void isPartOfGroup4() {
+        SpeciesGroup group = SpeciesGroup.builder()
+                .name("Test 1")
+                .rank("species")
+                .parent("Animals")
+                .lftRgtValues(Arrays.asList(
+                        LftRgtValues.builder().lft(150).rgt(250).tobeIncluded(false).build(),
+                        LftRgtValues.builder().lft(425).rgt(500).tobeIncluded(false).build(),
+                        LftRgtValues.builder().lft(100).rgt(400).tobeIncluded(true).build(),
+                        LftRgtValues.builder().lft(450).rgt(600).tobeIncluded(true).build()
+                ))
+                .build();
+        assertFalse(group.isPartOfGroup(200));
+        assertTrue(group.isPartOfGroup(100));
+        assertTrue(group.isPartOfGroup(300));
+        assertFalse(group.isPartOfGroup(425));
+        assertTrue(group.isPartOfGroup(500));
+    }
+
+
+    @Test
+    public void overlaps1() {
+        SpeciesGroup group1 = SpeciesGroup.builder()
+                .name("Test 1")
+                .rank("species")
+                .parent("Animals")
+                .lftRgtValues(Arrays.asList(
+                        LftRgtValues.builder().lft(100).rgt(400).tobeIncluded(true).build()
+                ))
+                .build();
+        assertTrue(group1.overlaps(group1));
+    }
+
+    @Test
+    public void overlaps2() {
+        SpeciesGroup group1 = SpeciesGroup.builder()
+                .name("Test 1")
+                .rank("species")
+                .parent("Animals")
+                .lftRgtValues(Arrays.asList(
+                        LftRgtValues.builder().lft(100).rgt(400).tobeIncluded(true).build()
+                ))
+                .build();
+        SpeciesGroup group2 = SpeciesGroup.builder()
+                .name("Test 2")
+                .rank("species")
+                .parent("Animals")
+                .lftRgtValues(Arrays.asList(
+                        LftRgtValues.builder().lft(400).rgt(500).tobeIncluded(true).build()
+                ))
+                .build();
+        assertFalse(group1.overlaps(group2));
+        assertFalse(group2.overlaps(group1));
+    }
+
+
+    @Test
+    public void overlaps3() {
+        SpeciesGroup group1 = SpeciesGroup.builder()
+                .name("Test 1")
+                .rank("species")
+                .parent("Animals")
+                .lftRgtValues(Arrays.asList(
+                        LftRgtValues.builder().lft(100).rgt(400).tobeIncluded(true).build()
+                ))
+                .build();
+        SpeciesGroup group2 = SpeciesGroup.builder()
+                .name("Test 2")
+                .rank("species")
+                .parent("Animals")
+                .lftRgtValues(Arrays.asList(
+                        LftRgtValues.builder().lft(300).rgt(500).tobeIncluded(true).build()
+                ))
+                .build();
+        assertTrue(group1.overlaps(group2));
+        assertTrue(group2.overlaps(group1));
+    }
+
+
+    @Test
+    public void overlaps4() {
+        SpeciesGroup group1 = SpeciesGroup.builder()
+                .name("Test 1")
+                .rank("species")
+                .parent("Animals")
+                .lftRgtValues(Arrays.asList(
+                        LftRgtValues.builder().lft(100).rgt(400).tobeIncluded(true).build(),
+                        LftRgtValues.builder().lft(500).rgt(600).tobeIncluded(true).build()
+                ))
+                .build();
+        SpeciesGroup group2 = SpeciesGroup.builder()
+                .name("Test 2")
+                .rank("species")
+                .parent("Animals")
+                .lftRgtValues(Arrays.asList(
+                        LftRgtValues.builder().lft(400).rgt(500).tobeIncluded(true).build()
+                ))
+                .build();
+        assertFalse(group1.overlaps(group2));
+        assertFalse(group2.overlaps(group1));
+    }
+
+
+    @Test
+    public void overlaps5() {
+        SpeciesGroup group1 = SpeciesGroup.builder()
+                .name("Test 1")
+                .rank("species")
+                .parent("Animals")
+                .lftRgtValues(Arrays.asList(
+                        LftRgtValues.builder().lft(150).rgt(200).tobeIncluded(false).build(),
+                        LftRgtValues.builder().lft(100).rgt(300).tobeIncluded(true).build()
+                ))
+                .build();
+        SpeciesGroup group2 = SpeciesGroup.builder()
+                .name("Test 2")
+                .rank("species")
+                .parent("Animals")
+                .lftRgtValues(Arrays.asList(
+                        LftRgtValues.builder().lft(150).rgt(200).tobeIncluded(true).build()
+                ))
+                .build();
+        assertFalse(group1.overlaps(group2));
+        assertFalse(group2.overlaps(group1));
+    }
+
+
+    @Test
+    public void overlaps6() {
+        SpeciesGroup group1 = SpeciesGroup.builder()
+                .name("Test 1")
+                .rank("species")
+                .parent("Animals")
+                .lftRgtValues(Arrays.asList(
+                        LftRgtValues.builder().lft(150).rgt(200).tobeIncluded(false).build(),
+                        LftRgtValues.builder().lft(100).rgt(300).tobeIncluded(true).build()
+                ))
+                .build();
+        SpeciesGroup group2 = SpeciesGroup.builder()
+                .name("Test 2")
+                .rank("species")
+                .parent("Animals")
+                .lftRgtValues(Arrays.asList(
+                        LftRgtValues.builder().lft(170).rgt(250).tobeIncluded(true).build()
+                ))
+                .build();
+        assertTrue(group1.overlaps(group2));
+        assertTrue(group2.overlaps(group1));
+    }
+
+    @Test
+    public void overlaps7() {
+        SpeciesGroup group1 = SpeciesGroup.builder()
+                .name("Test 1")
+                .rank("species")
+                .parent("Animals")
+                .lftRgtValues(Arrays.asList(
+                        LftRgtValues.builder().lft(150).rgt(200).tobeIncluded(false).build(),
+                        LftRgtValues.builder().lft(100).rgt(300).tobeIncluded(true).build()
+                ))
+                .build();
+        SpeciesGroup group2 = SpeciesGroup.builder()
+                .name("Test 2")
+                .rank("species")
+                .parent("Animals")
+                .lftRgtValues(Arrays.asList(
+                        LftRgtValues.builder().lft(170).rgt(190).tobeIncluded(false).build(),
+                        LftRgtValues.builder().lft(150).rgt(200).tobeIncluded(true).build()
+                ))
+                .build();
+        assertFalse(group1.overlaps(group2));
+        assertFalse(group2.overlaps(group1));
+    }
+
+
+    @Test
+    public void overlaps8() {
+        SpeciesGroup group1 = SpeciesGroup.builder()
+                .name("Test 1")
+                .rank("species")
+                .parent("Animals")
+                .lftRgtValues(Arrays.asList(
+                        LftRgtValues.builder().lft(100).rgt(200).tobeIncluded(true).build(),
+                        LftRgtValues.builder().lft(400).rgt(500).tobeIncluded(true).build()
+                ))
+                .build();
+        SpeciesGroup group2 = SpeciesGroup.builder()
+                .name("Test 2")
+                .rank("species")
+                .parent("Animals")
+                .lftRgtValues(Arrays.asList(
+                        LftRgtValues.builder().lft(50).rgt(90).tobeIncluded(true).build(),
+                        LftRgtValues.builder().lft(300).rgt(350).tobeIncluded(true).build()
+                ))
+                .build();
+        assertFalse(group1.overlaps(group2));
+        assertFalse(group2.overlaps(group1));
+    }
+
+}

--- a/server/src/test/java/au/org/ala/names/ws/core/SpeciesGroupsUtilTest.java
+++ b/server/src/test/java/au/org/ala/names/ws/core/SpeciesGroupsUtilTest.java
@@ -9,8 +9,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 public class SpeciesGroupsUtilTest extends TestUtils {
     private NameSearchConfiguration configuration;
@@ -41,8 +40,52 @@ public class SpeciesGroupsUtilTest extends TestUtils {
         return Integer.parseInt(result.getLeft());
     }
 
+    protected SpeciesGroup getGroup(String name) {
+        return this.speciesGroupsUtil.getSpeciesGroups().stream().filter(sg -> sg.name.equals(name)).findFirst().get();
+    }
+
+    protected SpeciesGroup getSubGroup(String name) {
+        return this.speciesGroupsUtil.getSpeciesSubgroups().stream().filter(sg -> sg.name.equals(name)).findFirst().get();
+    }
+
+    // Ensure separate species groups are separate
+    @Test
+    public void testLoad1() throws Exception {
+        SpeciesGroup mosses = this.getGroup("Mosses");
+        SpeciesGroup ferns = this.getGroup("Ferns And Allies");
+        assertNotNull(mosses);
+        assertNotNull(ferns);
+        assertFalse(mosses.overlaps(ferns));
+    }
+
+    // Ensure separate species subgroups are separate
+    @Test
+    public void testLoad2() throws Exception {
+        SpeciesGroup monocots = this.getSubGroup("Monocots");
+        SpeciesGroup dicots = this.getSubGroup("Dicots");
+        assertNotNull(monocots);
+        assertNotNull(dicots);
+        assertFalse(monocots.overlaps(dicots));
+    }
+
     @Test
     public void testGetGroup1() throws Exception {
+        int left = this.getLeft("Thylacinus cynocephalus");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Animals", "Mammals"), groups);
+    }
+
+    @Test
+    public void testGetSubGroup1() throws Exception {
+        int left = this.getLeft("Thylacinus cynocephalus");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Carnivorous Marsupials"), groups);
+    }
+
+    @Test
+    public void testGetGroup2() throws Exception {
         int left = this.getLeft("Osphranter rufus");
         List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
         assertNotNull(groups);
@@ -50,7 +93,99 @@ public class SpeciesGroupsUtilTest extends TestUtils {
     }
 
     @Test
-    public void testGetGroup2() throws Exception {
+    public void testGetSubGroup2() throws Exception {
+        int left = this.getLeft("Osphranter rufus");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Herbivorous Marsupials"), groups);
+    }
+
+
+    @Test
+    public void testGetGroup3() throws Exception {
+        int left = this.getLeft("Notoryctes caurinus");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Animals", "Mammals"), groups);
+    }
+
+    @Test
+    public void testGetSubGroup3() throws Exception {
+        int left = this.getLeft("Notoryctes caurinus");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Marsupial Moles"), groups);
+    }
+
+
+    @Test
+    public void testGetGroup4() throws Exception {
+        int left = this.getLeft("Perameles gunnii");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Animals", "Mammals"), groups);
+    }
+
+    @Test
+    public void testGetSubGroup4() throws Exception {
+        int left = this.getLeft("Perameles gunnii");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Bandicoots, Bilbies"), groups);
+    }
+
+
+    @Test
+    public void testGetGroup5() throws Exception {
+        int left = this.getLeft("Crocidura trichura");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Animals", "Mammals"), groups);
+    }
+
+    @Test
+    public void testGetSubGroup5() throws Exception {
+        int left = this.getLeft("Crocidura trichura");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList(), groups);
+    }
+
+    @Test
+    public void testGetGroup6() throws Exception {
+        int left = this.getLeft("Anas superciliosa");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Animals", "Birds"), groups);
+    }
+
+    @Test
+    public void testGetSubGroup6() throws Exception {
+        int left = this.getLeft("Anas superciliosa");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Ducks, Geese, Swans"), groups);
+    }
+
+
+    @Test
+    public void testGetGroup7() throws Exception {
+        int left = this.getLeft("Apus pacificus");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Animals", "Birds"), groups);
+    }
+
+    @Test
+    public void testGetSubGroup7() throws Exception {
+        int left = this.getLeft("Apus pacificus");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Hummingbirds, Swifts"), groups);
+    }
+
+    @Test
+    public void testGetGroup8() throws Exception {
         int left = this.getLeft("Dromaius novaehollandiae");
         List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
         assertNotNull(groups);
@@ -58,26 +193,284 @@ public class SpeciesGroupsUtilTest extends TestUtils {
     }
 
     @Test
-    public void testGetGroup3() throws Exception {
+    public void testGetSubGroup8() throws Exception {
+        int left = this.getLeft("Dromaius novaehollandiae");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList(), groups);
+    }
+
+    @Test
+    public void testGetGroup9() throws Exception {
+        int left = this.getLeft("Chelodina longicollis");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Animals", "Reptiles"), groups);
+    }
+
+    @Test
+    public void testGetSubGroup9() throws Exception {
+        int left = this.getLeft("Chelodina longicollis");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList(), groups);
+    }
+
+    @Test
+    public void testGetGroup10() throws Exception {
+        int left = this.getLeft("Litoria burrowsae");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Animals", "Amphibians"), groups);
+    }
+
+    @Test
+    public void testGetSubGroup10() throws Exception {
+        int left = this.getLeft("Litoria burrowsae");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList(), groups);
+    }
+
+    @Test
+    public void testGetGroup11() throws Exception {
+        int left = this.getLeft("Anguilla anguilla");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Animals", "Fishes"), groups);
+    }
+
+    @Test
+    public void testGetSubGroup11() throws Exception {
+        int left = this.getLeft("Anguilla anguilla");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList(), groups);
+    }
+
+    @Test
+    public void testGetGroup12() throws Exception {
+        int left = this.getLeft("Carditella mawsoni");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Animals", "Molluscs"), groups);
+    }
+
+    @Test
+    public void testGetSubGroup12() throws Exception {
+        int left = this.getLeft("Carditella mawsoni");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList(), groups);
+    }
+    @Test
+    public void testGetGroup13() throws Exception {
+        int left = this.getLeft("Australobranchipus gilgaiphila");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Animals", "Arthropods", "Crustaceans"), groups);
+    }
+
+    @Test
+    public void testGetSubGroup13() throws Exception {
+        int left = this.getLeft("Australobranchipus gilgaiphila");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList(), groups);
+    }
+
+    @Test
+    public void testGetGroup14() throws Exception {
+        int left = this.getLeft("Xenolepisma monteithi");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Animals", "Arthropods", "Insects"), groups);
+    }
+
+    @Test
+    public void testGetSubGroup14() throws Exception {
+        int left = this.getLeft("Xenolepisma monteithi");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList(), groups);
+    }
+
+    @Test
+    public void testGetGroup15() throws Exception {
+        int left = this.getLeft("Siphonotus brevicornis");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Animals", "Arthropods"), groups);
+    }
+
+    @Test
+    public void testGetSubGroup15() throws Exception {
+        int left = this.getLeft("Siphonotus brevicornis");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList(), groups);
+    }
+
+    @Test
+    public void testGetGroup16() throws Exception {
         int left = this.getLeft("Acacia dealbata");
         List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
         assertNotNull(groups);
-        assertEquals(Arrays.asList("Plants", "Angiosperms", "Dicots"), groups);
+        assertEquals(Arrays.asList("Plants", "Flowering Plants"), groups);
     }
 
     @Test
-    public void testGetSubgroup1() throws Exception {
-        int left = this.getLeft("Osphranter rufus");
+    public void testGetSubGroup16() throws Exception {
+        int left = this.getLeft("Acacia dealbata");
         List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
         assertNotNull(groups);
-        assertEquals(Arrays.asList("Herbivorous Marsupials"), groups);
+        assertEquals(Arrays.asList("Dicots"), groups);
+    }
+
+    // Issue 53
+    @Test
+    public void testGetGroup17() throws Exception {
+        int left = this.getLeft("Asparagus officinalis");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Plants", "Flowering Plants"), groups);
     }
 
     @Test
-    public void testGetSubgroup2() throws Exception {
-        int left = this.getLeft("Anas superciliosa");
+    public void testGetSubGroup17() throws Exception {
+        int left = this.getLeft("Asparagus officinalis");
         List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
         assertNotNull(groups);
-        assertEquals(Arrays.asList("Ducks, Geese, Swans"), groups);
+        assertEquals(Arrays.asList("Monocots"), groups);
     }
+
+    @Test
+    public void testGetGroup18() throws Exception {
+        int left = this.getLeft("Cycas arenicola");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Plants", "Conifers, Cycads"), groups);
+    }
+
+    @Test
+    public void testGetSubGroup18() throws Exception {
+        int left = this.getLeft("Cycas arenicola");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList(), groups);
+    }
+
+
+    @Test
+    public void testGetGroup19() throws Exception {
+        int left = this.getLeft("Equisetum arvense");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Plants", "Ferns And Allies"), groups);
+    }
+
+    @Test
+    public void testGetSubGroup19() throws Exception {
+        int left = this.getLeft("Equisetum arvense");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList(), groups);
+    }
+
+    @Test
+    public void testGetGroup20() throws Exception {
+        int left = this.getLeft("Brachymenium cellulare");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Plants", "Mosses"), groups);
+    }
+
+    @Test
+    public void testGetSubGroup20() throws Exception {
+        int left = this.getLeft("Brachymenium cellulare");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList(), groups);
+    }
+
+    @Test
+    public void testGetGroup21() throws Exception {
+        int left = this.getLeft("Antromycopsis leucopogonis");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Fungi"), groups);
+    }
+
+    @Test
+    public void testGetSubGroup21() throws Exception {
+        int left = this.getLeft("Antromycopsis leucopogonis");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList(), groups);
+    }
+
+    @Test
+    public void testGetGroup22() throws Exception {
+        int left = this.getLeft("Dinophysis acuminata");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Chromista"), groups);
+    }
+
+    @Test
+    public void testGetSubGroup22() throws Exception {
+        int left = this.getLeft("Dinophysis acuminata");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList(), groups);
+    }
+
+    @Test
+    public void testGetGroup23() throws Exception {
+        int left = this.getLeft("Parvicorbicula socialis");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Protozoa"), groups);
+    }
+
+    @Test
+    public void testGetSubGroup23() throws Exception {
+        int left = this.getLeft("Parvicorbicula socialis");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList(), groups);
+    }
+
+    @Test
+    public void testGetGroup24() throws Exception {
+        int left = this.getLeft("Caldisericum exile");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Bacteria"), groups);
+    }
+
+    @Test
+    public void testGetSubGroup24() throws Exception {
+        int left = this.getLeft("Caldisericum exile");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList(), groups);
+    }
+
+    @Test
+    public void testGetGroup25() throws Exception {
+        int left = this.getLeft("Plagioselmis prolonga");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList("Chromista", "Algae"), groups);
+    }
+
+    @Test
+    public void testGetSubGroup25() throws Exception {
+        int left = this.getLeft("Plagioselmis prolonga");
+        List<String> groups = this.speciesGroupsUtil.getSpeciesSubGroups(left);
+        assertNotNull(groups);
+        assertEquals(Arrays.asList(), groups);
+    }
+
 }

--- a/server/src/test/java/au/org/ala/names/ws/resources/NameSearchResourceTest.java
+++ b/server/src/test/java/au/org/ala/names/ws/resources/NameSearchResourceTest.java
@@ -549,7 +549,9 @@ public class NameSearchResourceTest {
         NameUsageMatch match = this.resource.match(search);
         assertNotNull(match);
         assertTrue(match.isSuccess());
-        assertEquals(1, match.getSpeciesGroup().size());
+        assertEquals(2, match.getSpeciesGroup().size());
+        assertEquals("Plants", match.getSpeciesGroup().get(0));
+        assertEquals("Flowering Plants", match.getSpeciesGroup().get(1));
     }
 
 }

--- a/server/src/test/java/au/org/ala/names/ws/resources/NameSearchResourceTest.java
+++ b/server/src/test/java/au/org/ala/names/ws/resources/NameSearchResourceTest.java
@@ -541,4 +541,15 @@ public class NameSearchResourceTest {
         assertNotNull(result);
         assertEquals(result.size(), 0);
     }
+
+
+    @Test
+    public void testGroups1() throws Exception {
+        NameSearch search = NameSearch.builder().scientificName("Asparagus officinalis").build();
+        NameUsageMatch match = this.resource.match(search);
+        assertNotNull(match);
+        assertTrue(match.isSuccess());
+        assertEquals(1, match.getSpeciesGroup().size());
+    }
+
 }

--- a/server/src/test/resources/au/org/ala/names/ws/core/test-groups-1.json
+++ b/server/src/test/resources/au/org/ala/names/ws/core/test-groups-1.json
@@ -1,142 +1,198 @@
-[{
-  "name": "Animals",
-  "rank": "kingdom",
-  "included": ["Animalia"],
-  "excluded": []
-},
+[
+  {
+    "name": "Animals",
+    "rank": "kingdom",
+    "included": [
+      "Animalia"
+    ],
+    "excluded": []
+  },
   {
     "name": "Mammals",
     "rank": "classs",
-    "included": ["Mammalia"],
+    "included": [
+      "Mammalia"
+    ],
     "excluded": [],
     "parent": "Animals"
   },
   {
     "name": "Birds",
     "rank": "classs",
-    "included": ["Aves"],
+    "included": [
+      "Aves"
+    ],
     "excluded": [],
     "parent": "Animals"
   },
   {
     "name": "Reptiles",
     "rank": "classs",
-    "included": ["Reptilia"],
+    "included": [
+      "Reptilia"
+    ],
     "excluded": [],
     "parent": "Animals"
   },
   {
     "name": "Amphibians",
     "rank": "classs",
-    "included": ["Amphibia"],
+    "included": [
+      "Amphibia"
+    ],
     "excluded": [],
     "parent": "Animals"
   },
   {
     "name": "Fishes",
     "rank": "classs",
-    "included": ["Agnatha", "Chondrichthyes", "Osteichthyes", "Actinopterygii", "Sarcopterygii"],
+    "included": [
+      "Agnatha",
+      "Chondrichthyes",
+      "Osteichthyes",
+      "Actinopterygii",
+      "Sarcopterygii"
+    ],
     "excluded": [],
     "parent": "Animals"
   },
   {
     "name": "Molluscs",
     "rank": "phylum",
-    "included": ["Mollusca"],
+    "included": [
+      "Mollusca"
+    ],
     "excluded": [],
     "parent": "Animals"
   },
   {
     "name": "Arthropods",
     "rank": "phylum",
-    "included": ["Arthropoda"],
+    "included": [
+      "Arthropoda"
+    ],
     "excluded": [],
     "parent": "Animals"
   },
   {
     "name": "Crustaceans",
     "rank": "classs",
-    "included": ["Branchiopoda", "Remipedia", "Maxillopoda", "Ostracoda", "Malacostraca"],
+    "included": [
+      "Branchiopoda",
+      "Remipedia",
+      "Maxillopoda",
+      "Ostracoda",
+      "Malacostraca"
+    ],
     "excluded": [],
     "parent": "Arthropods"
   },
   {
     "name": "Insects",
     "rank": "classs",
-    "included": ["Insecta"],
+    "included": [
+      "Insecta"
+    ],
     "excluded": [],
     "parent": "Arthropods"
   },
   {
     "name": "Plants",
     "rank": "kingdom",
-    "included": ["Plantae"],
+    "included": [
+      "Plantae"
+    ],
     "excluded": []
   },
   {
-    "name": "Gymnosperms",
+    "name": "Conifers, Cycads",
     "rank": "subclass",
-    "included": ["Pinidae", "Cycadidae"],
+    "included": [
+      "Pinidae",
+      "Cycadidae"
+    ],
     "excluded": [],
     "parent": "Plants"
   },
   {
-    "name": "FernsAndAllies",
+    "name": "Ferns And Allies",
     "rank": "subclass",
-    "included": ["Equisetidae", "Lycopodiidae", "Marattiidae", "Ophioglossidae", "Polypodiidae", "Psilotidae"],
+    "included": [
+      "Equisetidae",
+      "Lycopodiidae",
+      "Marattiidae",
+      "Ophioglossidae",
+      "Polypodiidae",
+      "Psilotidae"
+    ],
     "excluded": [],
     "parent": "Plants"
   },
   {
-    "name": "Angiosperms",
+    "name": "Flowering Plants",
     "rank": "subclass",
-    "included": ["Magnoliidae"],
+    "included": [
+      "Magnoliidae"
+    ],
     "excluded": [],
     "parent": "Plants"
   },
   {
-    "name": "Monocots",
-    "rank": "superorder",
-    "included": ["Lilianae"],
+    "name": "Mosses",
+    "rank": "phylum",
+    "included": [
+      "Bryophyta"
+    ],
     "excluded": [],
-    "parent": "Angiosperms"
-  },
-  {
-    "name": "Dicots",
-    "rank": "subclass",
-    "included": ["Magnoliidae"],
-    "excluded": ["Lilianae"],
-    "parent": "Angiosperms"
+    "parent": "Plants"
   },
   {
     "name": "Fungi",
-    "rank": "phylum",
-    "included": ["Fungi"],
+    "rank": "kingdom",
+    "included": [
+      "Fungi"
+    ],
     "excluded": []
   },
   {
     "name": "Chromista",
-    "rank": "phylum",
-    "included": ["Chromista"],
+    "rank": "kingdom",
+    "included": [
+      "Chromista"
+    ],
     "excluded": []
   },
   {
     "name": "Protozoa",
-    "rank": "phylum",
-    "included": ["Protozoa"],
+    "rank": "kingdom",
+    "included": [
+      "Protozoa"
+    ],
     "excluded": []
   },
   {
     "name": "Bacteria",
-    "rank": "phylum",
-    "included": ["Bacteria"],
+    "rank": "kingdom",
+    "included": [
+      "Bacteria"
+    ],
     "excluded": []
   },
   {
     "name": "Algae",
     "rank": "phylum",
-    "included": ["Bacillariophyta", "Chlorophyta", "Cyanidiophyta", "Prasinophyta", "Rhodophyta",
-      "Cryptophyta", "Ochrophyta", "Sagenista", "Cercozoa", "Euglenozoa", "Cyanobacteria"
+    "included": [
+      "Bacillariophyta",
+      "Chlorophyta",
+      "Cyanidiophyta",
+      "Prasinophyta",
+      "Rhodophyta",
+      "Cryptophyta",
+      "Ochrophyta",
+      "Sagenista",
+      "Cercozoa",
+      "Euglenozoa",
+      "Cyanobacteria"
     ],
     "excluded": []
   }

--- a/server/src/test/resources/au/org/ala/names/ws/core/test-subgroups-1.json
+++ b/server/src/test/resources/au/org/ala/names/ws/core/test-subgroups-1.json
@@ -1,63 +1,71 @@
 [
   {
-    "speciesGroup": "Mammals",
-    "taxonRank": "order",
+    "parent": "Mammals",
+    "rank": "order",
     "taxa": [
       {
-        "name": "DASYUROMORPHIA",
-        "common": "Carnivorous Marsupials"
+        "name": "Carnivorous Marsupials",
+        "included": [
+          "DASYUROMORPHIA"
+        ]
       },
       {
-        "name": "DIPROTODONTIA",
-        "common": "Herbivorous Marsupials"
+        "name": "Herbivorous Marsupials",
+        "included": [
+          "DIPROTODONTIA"
+        ]
       },
       {
-        "name": "NOTORYCTEMORPHIA",
-        "common": "Marsupial Moles"
+        "name": "Marsupial Moles",
+        "included": [
+          "NOTORYCTEMORPHIA"
+        ]
       },
       {
-        "name": "PERAMELEMORPHIA",
-        "common": "Bandicoots, Bilbies"
+        "name": "Bandicoots, Bilbies",
+        "included": [
+          "PERAMELEMORPHIA"
+        ]
       }
     ]
   },
   {
-    "speciesGroup": "Birds",
-    "taxonRank": "order",
+    "parent": "Birds",
+    "rank": "order",
     "taxa": [
       {
-        "name": "ANSERIFORMES",
-        "common": "Ducks, Geese, Swans"
+        "name": "Ducks, Geese, Swans",
+        "included": [
+          "ANSERIFORMES"
+        ]
       },
       {
-        "name": "APODIFORMES",
-        "common": "Hummingbirds, Swifts"
+        "name": "Hummingbirds, Swifts",
+        "included": [
+          "APODIFORMES"
+        ]
       }
     ]
   },
   {
-    "speciesGroup": "Plants",
-    "facetName": "species_group",
+    "parent": "Angiosperms",
     "taxa": [
       {
         "name": "Monocots",
-        "common": "Monocots"
+        "rank": "superorder",
+        "included": [
+          "Lilianae"
+        ]
       },
       {
         "name": "Dicots",
-        "common": "Dicots"
-      },
-      {
-        "name": "Angiosperms",
-        "common": "Flowering plants"
-      },
-      {
-        "name": "FernsAndAllies",
-        "common": "Ferns and Allies"
-      },
-      {
-        "name": "Gymnosperms",
-        "common": "Conifers, Cycads"
+        "rank": "subclass",
+        "included": [
+          "Magnoliidae"
+        ],
+        "excluded": [
+          "Lilianae"
+        ]
       }
     ]
   }


### PR DESCRIPTION
See issue #52

Group and subgroup names have been divided with group names largely at the class+ level and subgroups at the order level. Adjusted sabgroup file format to reflect the changes and makr it more similar to the group format.

Needs review to ensure that does not break any client expecting specific values.