### PR TITLE
Fixes for issue #62

### DIFF
--- a/ala-ws-client-common/pom.xml
+++ b/ala-ws-client-common/pom.xml
@@ -39,6 +39,16 @@
             <artifactId>cache2k-api</artifactId>
             <version>${cache2k.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.cache2k</groupId>
+            <artifactId>cache2k-addon</artifactId>
+            <version>${cache2k.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.cache2k</groupId>
+            <artifactId>cache2k-jmx</artifactId>
+            <version>${cache2k.version}</version>
+        </dependency>
 
         <!-- Retrofit without kotlin dependencies -->
         <dependency>

--- a/ala-ws-client-common/src/main/java/au/org/ala/ws/DataCacheConfiguration.java
+++ b/ala-ws-client-common/src/main/java/au/org/ala/ws/DataCacheConfiguration.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.cache2k.Cache2kBuilder;
+import org.cache2k.addon.UniversalResiliencePolicy;
+import org.cache2k.extra.jmx.JmxSupport;
 
 /**
  * A simple cache configuration for {@link Cache2kBuilder}.
@@ -66,12 +68,15 @@ public class DataCacheConfiguration {
      * @return A partially initialised builder.
      */
     public <K, V> Cache2kBuilder<K, V> cacheBuilder(Class<K> keyClass, Class<V> valueClass) {
-        return Cache2kBuilder.of(keyClass, valueClass)
-                .enableJmx(this.enableJmx)
+        Cache2kBuilder<K, V> builder = Cache2kBuilder.of(keyClass, valueClass)
                 .entryCapacity(this.entryCapacity)
                 .eternal(this.eternal)
                 .keepDataAfterExpired(this.keepDataAfterExpired)
-                .permitNullValues(this.permitNullValues)
-                .suppressExceptions(this.suppressExceptions);
+                .permitNullValues(this.permitNullValues);
+        if (enableJmx)
+            builder.enable(JmxSupport.class);
+        if (this.suppressExceptions)
+            builder.setup(UniversalResiliencePolicy::enable);
+        return builder;
     }
 }

--- a/ala-ws-client-common/src/test/java/au/org/ala/ws/ClientConfigurationTest.java
+++ b/ala-ws-client-common/src/test/java/au/org/ala/ws/ClientConfigurationTest.java
@@ -72,7 +72,7 @@ public class ClientConfigurationTest extends TestUtils {
         assertNotNull(cache);
         assertTrue(cache.isPresent());
         assertEquals("a:loaded", cache.get().get("a"));
-        cache.get().clearAndClose();
+        cache.get().close();
     }
 
     @Test

--- a/client/src/main/java/au/org/ala/names/ws/client/ALANameUsageMatchRetrofitService.java
+++ b/client/src/main/java/au/org/ala/names/ws/client/ALANameUsageMatchRetrofitService.java
@@ -3,6 +3,7 @@ package au.org.ala.names.ws.client;
 import au.org.ala.names.ws.api.NameMatchService;
 import au.org.ala.names.ws.api.NameSearch;
 import au.org.ala.names.ws.api.NameUsageMatch;
+import au.org.ala.names.ws.api.SearchStyle;
 import retrofit2.Call;
 import retrofit2.http.*;
 
@@ -37,12 +38,13 @@ interface ALANameUsageMatchRetrofitService {
             @Query("genus") String genus,
             @Query("specificEpithet") String specificEpithet,
             @Query("infraspecificEpithet") String infraspecificEpithet,
-            @Query("rank") String rank
+            @Query("rank") String rank,
+            @Query("style")SearchStyle style
     );
 
     @GET("/api/search")
     @Headers({"Content-Type: application/json"})
-    Call<NameUsageMatch> match(@Query("q") String scientificName);
+    Call<NameUsageMatch> match(@Query("q") String scientificName, @Query("style") SearchStyle style);
 
     @GET("/api/searchByVernacularName")
     @Headers({"Content-Type: application/json"})

--- a/client/src/main/java/au/org/ala/names/ws/client/ALANameUsageMatchServiceClient.java
+++ b/client/src/main/java/au/org/ala/names/ws/client/ALANameUsageMatchServiceClient.java
@@ -3,6 +3,7 @@ package au.org.ala.names.ws.client;
 import au.org.ala.names.ws.api.NameMatchService;
 import au.org.ala.names.ws.api.NameSearch;
 import au.org.ala.names.ws.api.NameUsageMatch;
+import au.org.ala.names.ws.api.SearchStyle;
 import au.org.ala.ws.ClientConfiguration;
 import au.org.ala.ws.ClientException;
 import lombok.extern.slf4j.Slf4j;
@@ -125,12 +126,13 @@ public class ALANameUsageMatchServiceClient implements NameMatchService {
      * @param specificEpithet      The specific epithet (species component of a binomial name)
      * @param infraspecificEpithet The infraspecific epithet (subspecies, variety etc component of a trinomial name)
      * @param rank                 The Linnaean rank name
+     * @param style                The search style (defaults to {@link au.org.ala.names.ws.api.SearchStyle#MATCH}
      * @return A matching taxon, with success=false if not found
      * @see #match(NameSearch)
      */
     @Override
-    public NameUsageMatch match(String scientificName, String kingdom, String phylum, String clazz, String order, String family, String genus, String specificEpithet, String infraspecificEpithet, String rank) {
-        return this.call(this.alaNameUsageMatchService.match(scientificName, kingdom, phylum, clazz, order, family, genus, specificEpithet, infraspecificEpithet, rank));
+    public NameUsageMatch match(String scientificName, String kingdom, String phylum, String clazz, String order, String family, String genus, String specificEpithet, String infraspecificEpithet, String rank, SearchStyle style) {
+        return this.call(this.alaNameUsageMatchService.match(scientificName, kingdom, phylum, clazz, order, family, genus, specificEpithet, infraspecificEpithet, rank, style));
     }
 
     /**
@@ -141,11 +143,12 @@ public class ALANameUsageMatchServiceClient implements NameMatchService {
      * </p>
      *
      * @param scientificName The scientific name of the taxon
+     * @param style The search style (defaults to {@link au.org.ala.names.ws.api.SearchStyle#MATCH}
      * @return A matching taxon, with success=false if not found
      */
     @Override
-    public NameUsageMatch match(String scientificName) {
-        return this.call(this.alaNameUsageMatchService.match(scientificName));
+    public NameUsageMatch match(String scientificName, SearchStyle style) {
+        return this.call(this.alaNameUsageMatchService.match(scientificName, style));
     }
 
     /**

--- a/client/src/test/java/au/org/ala/names/ws/client/ALANameUsageMatchServiceCachingClientTest.java
+++ b/client/src/test/java/au/org/ala/names/ws/client/ALANameUsageMatchServiceCachingClientTest.java
@@ -236,7 +236,7 @@ public class ALANameUsageMatchServiceCachingClientTest extends TestUtils {
     public void testError1() throws Exception {
         server.enqueue(new MockResponse().setResponseCode(500).setBody("Unable to connect to index"));
         try {
-            NameUsageMatch match = client.match("Acacia dealbata");
+            NameUsageMatch match = client.match("Acacia dealbata", null);
             fail("Expecting HttpException");
         } catch (HttpException ex) {
             assertEquals(500, ex.code());

--- a/client/src/test/java/au/org/ala/names/ws/client/ALANameUsageMatchServiceClientIT.java
+++ b/client/src/test/java/au/org/ala/names/ws/client/ALANameUsageMatchServiceClientIT.java
@@ -4,6 +4,7 @@ import au.org.ala.names.ws.ALANameMatchingServiceApplication;
 import au.org.ala.names.ws.ALANameMatchingServiceConfiguration;
 import au.org.ala.names.ws.api.NameSearch;
 import au.org.ala.names.ws.api.NameUsageMatch;
+import au.org.ala.names.ws.api.SearchStyle;
 import au.org.ala.util.TestUtils;
 import au.org.ala.ws.ClientConfiguration;
 import au.org.ala.ws.DataCacheConfiguration;
@@ -86,6 +87,39 @@ public class ALANameUsageMatchServiceClientIT extends TestUtils {
         assertTrue(match.isSuccess());
         assertEquals("Acacia dealbata", match.getScientificName());
         assertEquals(Collections.singletonList("hintMismatch"), match.getIssues());
+    }
+
+    /** Supply style */
+    @Test
+    public void testMatchNameSearch4() throws Exception {
+        NameSearch search = NameSearch.builder().scientificName("Acacia dealbata").style(SearchStyle.STRICT).build();
+        NameUsageMatch match = client.match(search);
+
+        assertTrue(match.isSuccess());
+        assertEquals("Acacia dealbata", match.getScientificName());
+        assertEquals(Collections.singletonList("noIssue"), match.getIssues());
+    }
+
+
+    /** Supply style */
+    @Test
+    public void testMatchNameSearch5() throws Exception {
+        NameSearch search = NameSearch.builder().scientificName("Akacia dealbata").style(SearchStyle.FUZZY).build();
+        NameUsageMatch match = client.match(search);
+
+        assertTrue(match.isSuccess());
+        assertEquals(Collections.singletonList("noIssue"), match.getIssues());
+    }
+
+
+    /** Supply style */
+    @Test
+    public void testMatchNameSearch6() throws Exception {
+        NameSearch search = NameSearch.builder().scientificName("Akacia dealbata").style(SearchStyle.STRICT).build();
+        NameUsageMatch match = client.match(search);
+
+        assertFalse(match.isSuccess());
+        assertEquals(Collections.singletonList("noMatch"), match.getIssues());
     }
 
 
@@ -190,7 +224,7 @@ public class ALANameUsageMatchServiceClientIT extends TestUtils {
     /** Simple request/response */
     @Test
     public void testMatchNameParams1() throws Exception {
-        NameUsageMatch match = client.match("Acacia dealbata", "Plantae", null, null, null, null, null, null, null, null);
+        NameUsageMatch match = client.match("Acacia dealbata", "Plantae", null, null, null, null, null, null, null, null, null);
 
         assertTrue(match.isSuccess());
         assertEquals("Acacia dealbata", match.getScientificName());
@@ -201,12 +235,32 @@ public class ALANameUsageMatchServiceClientIT extends TestUtils {
     /** Simple name match */
     @Test
     public void testMatchName1() throws Exception {
-        NameUsageMatch match = client.match("Acacia dealbata");
+        NameUsageMatch match = client.match("Acacia dealbata", null);
 
         assertTrue(match.isSuccess());
         assertEquals("Acacia dealbata", match.getScientificName());
         assertEquals("species", match.getRank());
         assertEquals("https://id.biodiversity.org.au/taxon/apni/51286863", match.getTaxonConceptID());
+    }
+
+
+    /** Simple name match with style */
+    @Test
+    public void testMatchName2() throws Exception {
+        NameUsageMatch match = client.match("Acacia dealbata", SearchStyle.STRICT);
+
+        assertTrue(match.isSuccess());
+        assertEquals("Acacia dealbata", match.getScientificName());
+        assertEquals("species", match.getRank());
+        assertEquals("https://id.biodiversity.org.au/taxon/apni/51286863", match.getTaxonConceptID());
+    }
+
+    /** Simple name match with style */
+    @Test
+    public void testMatchName3() throws Exception {
+        NameUsageMatch match = client.match("Acacia dealbatae", SearchStyle.STRICT);
+
+        assertFalse(match.isSuccess());
     }
 
     /** Simple vernacular name match */

--- a/client/src/test/java/au/org/ala/names/ws/client/ALANameUsageMatchServiceClientTest.java
+++ b/client/src/test/java/au/org/ala/names/ws/client/ALANameUsageMatchServiceClientTest.java
@@ -2,6 +2,7 @@ package au.org.ala.names.ws.client;
 
 import au.org.ala.names.ws.api.NameSearch;
 import au.org.ala.names.ws.api.NameUsageMatch;
+import au.org.ala.names.ws.api.SearchStyle;
 import au.org.ala.util.TestUtils;
 import au.org.ala.ws.ClientConfiguration;
 import au.org.ala.ws.ClientException;
@@ -101,6 +102,26 @@ public class ALANameUsageMatchServiceClientTest extends TestUtils {
         assertEquals(request, req.getBody().readUtf8());
     }
 
+    @Test
+    public void testMatchNameSearch4() throws Exception {
+        String request = this.getResource("request-4.json");
+        String response = this.getResource("response-3.json");
+
+        server.enqueue(new MockResponse().setBody(response));
+        Map<String, List<String>> hints = new HashMap<>();
+        hints.put("kingdom", Arrays.asList("Animalia"));
+        NameSearch search = NameSearch.builder().scientificName("Acacia dealbata").hints(hints).style(SearchStyle.STRICT).build();
+        NameUsageMatch match = client.match(search);
+
+        assertTrue(match.isSuccess());
+        assertEquals("Acacia dealbata", match.getScientificName());
+        assertEquals(Collections.singletonList("hintMismatch"), match.getIssues());
+        assertEquals(1, server.getRequestCount());
+        RecordedRequest req = server.takeRequest();
+        assertEquals("/api/searchByClassification", req.getPath());
+        assertEquals(request, req.getBody().readUtf8());
+    }
+
     /** Multiple search */
     @Test
     public void testMatchAllNameSearch1() throws Exception {
@@ -162,7 +183,7 @@ public class ALANameUsageMatchServiceClientTest extends TestUtils {
         String response = this.getResource("response-1.json");
 
         server.enqueue(new MockResponse().setBody(response));
-        NameUsageMatch match = client.match("Acacia dealbata", "Plantae", null, null, null, null, null, null, null, null);
+        NameUsageMatch match = client.match("Acacia dealbata", "Plantae", null, null, null, null, null, null, null, null, null);
 
         assertTrue(match.isSuccess());
         assertEquals("Acacia dealbata", match.getScientificName());
@@ -180,9 +201,9 @@ public class ALANameUsageMatchServiceClientTest extends TestUtils {
         server.enqueue(new MockResponse().addHeader("Cache-Control: max-age=60").setBody(response));
         server.enqueue(new MockResponse().setResponseCode(500));
 
-        NameUsageMatch match = client.match("Acacia dealbata", "Plantae", null, null, null, null, null, null, null, null);
-        match = client.match("Acacia dealbata", "Plantae", null, null, null, null, null, null, null, null);
-        match = client.match("Acacia dealbata", "Plantae", null, null, null, null, null, null, null, null);
+        NameUsageMatch match = client.match("Acacia dealbata", "Plantae", null, null, null, null, null, null, null, null, null);
+        match = client.match("Acacia dealbata", "Plantae", null, null, null, null, null, null, null, null, null);
+        match = client.match("Acacia dealbata", "Plantae", null, null, null, null, null, null, null, null, null);
 
         assertTrue(match.isSuccess());
         assertEquals("Acacia dealbata", match.getScientificName());
@@ -197,7 +218,7 @@ public class ALANameUsageMatchServiceClientTest extends TestUtils {
         String response = this.getResource("response-1.json");
 
         server.enqueue(new MockResponse().setBody(response));
-        NameUsageMatch match = client.match("Acacia dealbata");
+        NameUsageMatch match = client.match("Acacia dealbata", null);
 
         assertTrue(match.isSuccess());
         assertEquals("Acacia dealbata", match.getScientificName());
@@ -215,9 +236,9 @@ public class ALANameUsageMatchServiceClientTest extends TestUtils {
 
         server.enqueue(new MockResponse().addHeader("Cache-Control: max-age=60").setBody(response));
         server.enqueue(new MockResponse().setResponseCode(500));
-        NameUsageMatch match = client.match("Acacia dealbata");
-        match = client.match("Acacia dealbata");
-        match = client.match("Acacia dealbata");
+        NameUsageMatch match = client.match("Acacia dealbata", null);
+        match = client.match("Acacia dealbata", null);
+        match = client.match("Acacia dealbata", null);
 
         assertTrue(match.isSuccess());
         assertEquals("Acacia dealbata", match.getScientificName());
@@ -263,7 +284,7 @@ public class ALANameUsageMatchServiceClientTest extends TestUtils {
     public void testError1() throws Exception {
         server.enqueue(new MockResponse().setResponseCode(500).setBody("Unable to connect to index"));
         try {
-            NameUsageMatch match = client.match("Acacia dealbata");
+            NameUsageMatch match = client.match("Acacia dealbata", null);
             fail("Expecting HttpException");
         } catch (HttpException ex) {
             assertEquals(500, ex.code());
@@ -280,7 +301,7 @@ public class ALANameUsageMatchServiceClientTest extends TestUtils {
         try {
             ClientConfiguration errorConfiguration = ClientConfiguration.builder().baseUrl(new URL("http://nothing.nowhere")).build();
             this.client = new ALANameUsageMatchServiceClient(errorConfiguration);
-            NameUsageMatch match = client.match("Acacia dealbata");
+            NameUsageMatch match = client.match("Acacia dealbata", null);
             fail("Expecting ClientException");
         } catch (ClientException ex) {
         }

--- a/client/src/test/resources/au/org/ala/names/ws/client/request-4.json
+++ b/client/src/test/resources/au/org/ala/names/ws/client/request-4.json
@@ -1,0 +1,1 @@
+{"scientificName":"Acacia dealbata","hints":{"kingdom":["Animalia"]},"style":"STRICT"}

--- a/core/src/main/java/au/org/ala/names/ws/api/NameMatchService.java
+++ b/core/src/main/java/au/org/ala/names/ws/api/NameMatchService.java
@@ -57,6 +57,7 @@ public interface NameMatchService extends Closeable {
      * @param specificEpithet The specific epithet (species component of a binomial name)
      * @param infraspecificEpithet The infraspecific epithet (subspecies, variety etc component of a trinomial name)
      * @param rank The Linnaean rank name
+     * @param style The search style to use
      *
      * @return A matching taxon, with success=false if not found
      */
@@ -70,7 +71,8 @@ public interface NameMatchService extends Closeable {
             String genus,
             String specificEpithet,
             String infraspecificEpithet,
-            String rank
+            String rank,
+            SearchStyle style
     );
 
     /**
@@ -81,10 +83,11 @@ public interface NameMatchService extends Closeable {
      * </p>
      *
      * @param scientificName The scientific name of the taxon
+     * @param style The search style to use
      *
      * @return A matching taxon, with success=false if not found
      */
-    NameUsageMatch match(String scientificName);
+    NameUsageMatch match(String scientificName, SearchStyle style);
 
     /**
      * Search for a taxon with a given vernacular (common) name.

--- a/core/src/main/java/au/org/ala/names/ws/api/NameSearch.java
+++ b/core/src/main/java/au/org/ala/names/ws/api/NameSearch.java
@@ -144,6 +144,11 @@ public class NameSearch {
         description = "Allow a loose search. Loose searches will treat the scientific name as a vernacular name or a taxon identifier if the name cannot be found."
     )
     private boolean loose;
+    @Schema(
+            example = "MATCH",
+            description = "The style of search to perform. If absent, the server default style is used."
+    )
+    private SearchStyle style;
 
     /**
      * Get a version of this that has been normalised.
@@ -179,6 +184,7 @@ public class NameSearch {
                     )
             )
             .loose(this.loose)
+            .style(this.style)
             .build();
     }
 

--- a/core/src/main/java/au/org/ala/names/ws/api/NameUsageMatch.java
+++ b/core/src/main/java/au/org/ala/names/ws/api/NameUsageMatch.java
@@ -241,6 +241,33 @@ public class NameUsageMatch {
         return true;
     }
 
+    /**
+     * Return information about the error that has occurred.
+     *
+     * @param ex The error
+     * @param search The search that caused the error (may be null)
+     *
+     * @return An error match.
+     */
+    public static NameUsageMatch forException(Exception ex, NameSearch search) {
+        StringBuffer message = new StringBuffer();
+
+        message.append("Internal error ");
+        message.append(ex.getClass());
+        if (ex.getMessage() != null) {
+            message.append(": ");
+            message.append(ex.getMessage());
+        }
+        if (search != null) {
+            message.append(" for ");
+            message.append(search);
+        }
+        return NameUsageMatch.builder()
+                .success(false)
+                .issues(Collections.singletonList(message.toString()))
+                .build();
+    }
+
 
     @JsonPOJOBuilder(withPrefix = "")
     public static class NameUsageMatchBuilder {}

--- a/core/src/main/java/au/org/ala/names/ws/api/SearchStyle.java
+++ b/core/src/main/java/au/org/ala/names/ws/api/SearchStyle.java
@@ -1,0 +1,51 @@
+package au.org.ala.names.ws.api;
+
+import lombok.Getter;
+
+/**
+ * The type of search to undertake.
+ */
+public enum SearchStyle {
+    /**
+     * Standard match search.
+     * <p>
+     * The default.
+     * Used for record name matching.
+     * Includes higher-order matching, fuzzy matching and other
+     *
+     * </p>
+     */
+    MATCH(true, true, true),
+    /**
+     * Fuzzy matching.
+     * <p>
+     * Allow matching with allowance for misspelled names.
+     * But no matching to higher-order concepts.
+     * </p>
+     */
+    FUZZY(true, true, false),
+    /**
+     * Strict matching.
+     * <p>
+     * Used for exact matches in the case of list lookups, etc.
+     * Only exact or canonical matches are accepted.
+     * </p>
+     */
+    STRICT(false, false, false);
+
+    /** Is this style loose by default? */
+    @Getter
+    private boolean loose;
+    /** Does this style allow fuzzy lookups? */
+    @Getter
+    private boolean fuzzy;
+    /** Does this style allow higher order lookups? */
+    @Getter
+    private boolean hisherOrder;
+
+    SearchStyle(boolean loose, boolean fuzzy, boolean higherOrder) {
+        this.loose = loose;
+        this.fuzzy = fuzzy;
+        this.hisherOrder = higherOrder;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <ala-name-matching.version>4.2</ala-name-matching.version>
-        <cache2k.version>1.2.0.Final</cache2k.version>
+        <cache2k.version>2.6.1.Final</cache2k.version>
         <jackson.version>2.14.0</jackson.version>
         <retrofit.version>2.6.2</retrofit.version>
         <okhttp.version>4.3.1</okhttp.version>

--- a/server/src/main/java/au/org/ala/names/ws/ALANameMatchingServiceConfiguration.java
+++ b/server/src/main/java/au/org/ala/names/ws/ALANameMatchingServiceConfiguration.java
@@ -14,8 +14,7 @@ import lombok.Setter;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.Collections;
 
 public class ALANameMatchingServiceConfiguration extends Configuration {
     /** The swagger UI configuration */
@@ -45,7 +44,7 @@ public class ALANameMatchingServiceConfiguration extends Configuration {
     /**
      * Construct with default setttings.
      * <p>
-     * The settings can be overridden in the
+     * The settings can be overridden in the configuraion YAML file
      * </p>
      */
     public ALANameMatchingServiceConfiguration()  {
@@ -56,7 +55,7 @@ public class ALANameMatchingServiceConfiguration extends Configuration {
         this.swaggerBundleConfiguration.setContactEmail("support@ala.org.au");
         this.swaggerBundleConfiguration.setResourcePackage("au.org.ala.names.ws.api,au.org.ala.names.ws.client,au.org.ala.names.ws.resources");
         this.swaggerBundleConfiguration.setLicense("Mozilla Public Licence 1.1");
-        this.swaggerBundleConfiguration.setVersion("1.8-SNAPSHOT");
+        this.swaggerBundleConfiguration.setVersion("1.9-SNAPSHOT");
         this.swaggerBundleConfiguration.getSwaggerViewConfiguration().setPageTitle("ALA Namematching API");
 
         // swagger openapi v3
@@ -64,15 +63,18 @@ public class ALANameMatchingServiceConfiguration extends Configuration {
         Info info = new Info()
                 .title("ALA Namematching API")
                 .description("A taxonomy service that maps scientific name queries onto taxon concepts")
-                .contact(new Contact().email("support@ala.org.au").url("https://ala.org.au"))
-                .license(new License().name("Mozilla Public Licence 1.1"))
-                .version("1.8-SNAPSHOT");
+                .contact(new Contact()
+                        .email("support@ala.org.au")
+                        .url("https://ala.org.au"))
+                .license(new License()
+                        .name("Mozilla Public Licence 1.1")
+                        .url("https://www.mozilla.org/en-US/MPL/1.1/"))
+                .version("1.9-SNAPSHOT");
 
         oas.info(info);
-        swaggerConfiguration = new SwaggerConfiguration()
+        this.swaggerConfiguration = new SwaggerConfiguration()
                 .openAPI(oas)
                 .prettyPrint(true)
-                .resourcePackages(Stream.of("au.org.ala.names.ws")
-                        .collect(Collectors.toSet()));
-    }
+                .resourcePackages(Collections.singleton("au.org.ala.names.ws.resources"));
+     }
 }

--- a/server/src/main/java/au/org/ala/names/ws/core/NameSearchConfiguration.java
+++ b/server/src/main/java/au/org/ala/names/ws/core/NameSearchConfiguration.java
@@ -1,5 +1,6 @@
 package au.org.ala.names.ws.core;
 
+import au.org.ala.names.ws.api.SearchStyle;
 import au.org.ala.ws.DataCacheConfiguration;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -32,7 +33,11 @@ public class NameSearchConfiguration {
     @JsonProperty
     private boolean checkHints = true;
     /** Allow loose searching on taxon identifier and vernacular name in place of scientific name, if requested */
+    @JsonProperty
     private boolean allowLoose = true;
+    /** The default search style to use, if not specified */
+    @JsonProperty
+    private SearchStyle defaultStyle = SearchStyle.MATCH;
     /** The cache configuration */
     @JsonProperty
     private DataCacheConfiguration cache = DataCacheConfiguration.builder().build();

--- a/server/src/main/java/au/org/ala/names/ws/health/NameSearchHealthCheck.java
+++ b/server/src/main/java/au/org/ala/names/ws/health/NameSearchHealthCheck.java
@@ -3,6 +3,8 @@ package au.org.ala.names.ws.health;
 import au.org.ala.names.ws.resources.NameSearchResource;
 import com.codahale.metrics.health.HealthCheck;
 
+import java.util.Map;
+
 /**
  * Health check for the name search resource, to make
  * sure that nothing has gone away by accident.
@@ -16,9 +18,13 @@ public class NameSearchHealthCheck extends HealthCheck {
 
     @Override
     protected Result check() throws Exception {
-        if (this.resource.check())
-            return Result.healthy();
-        else
+        if (this.resource.check()) {
+            return Result.builder()
+                    .healthy()
+                    .withDetail("metrics", this.resource.getMetrics())
+                    .build();
+        } else {
             return Result.unhealthy("Name search unable to search index");
+        }
     }
 }

--- a/server/src/test/java/au/org/ala/names/ws/resources/NameSearchResourceTest.java
+++ b/server/src/test/java/au/org/ala/names/ws/resources/NameSearchResourceTest.java
@@ -2,6 +2,7 @@ package au.org.ala.names.ws.resources;
 
 import au.org.ala.names.ws.api.NameSearch;
 import au.org.ala.names.ws.api.NameUsageMatch;
+import au.org.ala.names.ws.api.SearchStyle;
 import au.org.ala.names.ws.core.NameSearchConfiguration;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
@@ -34,7 +35,7 @@ public class NameSearchResourceTest {
 
     @Test
     public void testSearch1() throws Exception {
-        NameUsageMatch match = this.resource.match("Acacia dealbata");
+        NameUsageMatch match = this.resource.match("Acacia dealbata", SearchStyle.MATCH);
         assertTrue(match.isSuccess());
         assertEquals("Acacia dealbata", match.getScientificName());
         assertEquals("species", match.getRank());
@@ -47,13 +48,42 @@ public class NameSearchResourceTest {
     // Vernacular name in scientific name
     @Test
     public void testSearch2() throws Exception {
-        NameUsageMatch match = this.resource.match("Slender Violet-bush");
+        NameUsageMatch match = this.resource.match("Slender Violet-bush", SearchStyle.MATCH);
         assertTrue(match.isSuccess());
         assertEquals("Hybanthus monopetalus", match.getScientificName());
         assertEquals("species", match.getRank());
         assertEquals("https://id.biodiversity.org.au/node/apni/2887517", match.getTaxonConceptID());
         assertEquals("vernacularMatch", match.getMatchType());
         assertEquals(Collections.singletonList("noIssue"), match.getIssues());
+    }
+
+    @Test
+    public void testSearch3() throws Exception {
+        NameUsageMatch match = this.resource.match("Acacia dealbata", SearchStyle.STRICT);
+        assertTrue(match.isSuccess());
+        assertEquals("Acacia dealbata", match.getScientificName());
+        assertEquals("species", match.getRank());
+        assertEquals("https://id.biodiversity.org.au/taxon/apni/51286863", match.getTaxonConceptID());
+        assertEquals("exactMatch", match.getMatchType());
+        assertEquals(Collections.singletonList("noIssue"), match.getIssues());
+    }
+
+    @Test
+    public void testSearch4() throws Exception {
+        NameUsageMatch match = this.resource.match("Acacia otherwise", SearchStyle.MATCH);
+        assertTrue(match.isSuccess());
+        assertEquals("Acacia", match.getScientificName());
+        assertEquals("genus", match.getRank());
+        assertEquals("https://id.biodiversity.org.au/taxon/apni/51382879", match.getTaxonConceptID());
+        assertEquals("higherMatch", match.getMatchType());
+        assertEquals(Collections.singletonList("noIssue"), match.getIssues());
+    }
+
+    @Test
+    public void testSearch5() throws Exception {
+        NameUsageMatch match = this.resource.match("Acacia otherwise", SearchStyle.STRICT);
+        assertFalse(match.isSuccess());
+        assertEquals(Collections.singletonList("noMatch"), match.getIssues());
     }
 
     @Test
@@ -91,7 +121,7 @@ public class NameSearchResourceTest {
 
     @Test
     public void testSearchByClassification4() throws Exception {
-        NameUsageMatch match = this.resource.match("Osphranter rufus", null, null, null, null, null, null, null, null, null);
+        NameUsageMatch match = this.resource.match("Osphranter rufus", null, null, null, null, null, null, null, null, null, null);
         assertTrue(match.isSuccess());
         assertEquals("Osphranter rufus", match.getScientificName());
         assertEquals("Animalia", match.getKingdom());
@@ -101,7 +131,7 @@ public class NameSearchResourceTest {
 
     @Test
     public void testSearchByClassification5() throws Exception {
-        NameUsageMatch match = this.resource.match(null, null, null, null, null, null, "Osphranter", "rufus", null, null);
+        NameUsageMatch match = this.resource.match(null, null, null, null, null, null, "Osphranter", "rufus", null, null, null);
         assertTrue(match.isSuccess());
         assertEquals("Osphranter rufus", match.getScientificName());
         assertEquals("Animalia", match.getKingdom());
@@ -112,7 +142,7 @@ public class NameSearchResourceTest {
 
     @Test
     public void testSearchByClassification6() throws Exception {
-        NameUsageMatch match = this.resource.match(null, null, null, null, null, "Pterophoridae", null, null, null, null);
+        NameUsageMatch match = this.resource.match(null, null, null, null, null, "Pterophoridae", null, null, null, null, null);
         assertTrue(match.isSuccess());
         assertEquals("PTEROPHORIDAE", match.getScientificName());
         assertEquals("Animalia", match.getKingdom());
@@ -160,6 +190,44 @@ public class NameSearchResourceTest {
         assertEquals("https://id.biodiversity.org.au/node/apni/5272169", match.getTaxonConceptID());
         assertEquals("taxonIdMatch", match.getMatchType());
         assertEquals(Collections.singletonList("noIssue"), match.getIssues());
+    }
+
+    @Test
+    public void testSearchByClassification11() throws Exception {
+        NameUsageMatch match = this.resource.match("Eucalyptus globula", null, null, null, null, null, null, null, null, null, SearchStyle.MATCH);
+        assertTrue(match.isSuccess());
+        assertEquals("Eucalyptus globulus", match.getScientificName());
+        assertEquals("https://id.biodiversity.org.au/node/apni/5272169", match.getTaxonConceptID());
+        assertEquals("fuzzyMatch", match.getMatchType());
+        assertEquals(Collections.singletonList("noIssue"), match.getIssues());
+    }
+
+
+    @Test
+    public void testSearchByClassification12() throws Exception {
+        NameUsageMatch match = this.resource.match("Eucalyptus globula", null, null, null, null, null, null, null, null, null, SearchStyle.FUZZY);
+        assertTrue(match.isSuccess());
+        assertEquals("Eucalyptus globulus", match.getScientificName());
+        assertEquals("https://id.biodiversity.org.au/node/apni/5272169", match.getTaxonConceptID());
+        assertEquals("fuzzyMatch", match.getMatchType());
+        assertEquals(Collections.singletonList("noIssue"), match.getIssues());
+    }
+
+
+    @Test
+    public void testSearchByClassification13() throws Exception {
+        NameUsageMatch match = this.resource.match("Eucalyptus globula", null, null, null, null, null, null, null, null, null, SearchStyle.STRICT);
+        assertFalse(match.isSuccess());
+        assertEquals(Collections.singletonList("noMatch"), match.getIssues());
+    }
+
+
+
+    @Test
+    public void testSearchByClassification14() throws Exception {
+        NameUsageMatch match = this.resource.match("Eucalyptus rightmessofaname", null, null, null, null, null, null, null, null, null, SearchStyle.FUZZY);
+        assertFalse(match.isSuccess());
+        assertEquals(Collections.singletonList("noMatch"), match.getIssues());
     }
 
 


### PR DESCRIPTION
The ability to specify a search style *should* be compatible with old clients, with the queries defaulting to the MATCH style.

Report config and metrics during health check