### PR TITLE
Fix #73: Remove the maven-project-info-reports-plugin from dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,12 +97,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-project-info-reports-plugin</artifactId>
-            <version>3.4.1</version>
-            <type>maven-plugin</type>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
maven-project-info-reports-plugin is included in maven's default reporting plugins, so there should be no need to add the full co-ordindates as a build pluginManagement or reporting dependency.