### PR TITLE
Remove debug log line

### DIFF
--- a/server/src/main/java/au/org/ala/names/ws/resources/NameSearchResource.java
+++ b/server/src/main/java/au/org/ala/names/ws/resources/NameSearchResource.java
@@ -399,7 +399,6 @@ public class NameSearchResource implements NameMatchService {
     @Path("/getGuidsForTaxa")
     public List<String> getGuidsForTaxa(List<String> taxa) {
         try {
-            log.error("getGuisForTaxa:" + taxa.size());
             List<String> guids = this.searcher.getGuidsForTaxa(taxa);
             return guids;
         } catch (Exception e){


### PR DESCRIPTION
Simply remove a hanging debug line that is logging at error level.

In the middle of setting up monitoring for our environment and it is causing some of our alerts to fire.